### PR TITLE
maint: cover nipype workflow migration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ setup_requires =
 install_requires =
     nibabel >=2.2.1
     nipype >=1.2.0
+    niflow-nipype1-workflows
     niworkflows ~=0.10
     numpy
     pybids ~=0.9.2


### PR DESCRIPTION
adds `niflow-nipype1-workflows` for old nipype workflow support