### PR TITLE
MNT: Use niflow-nipype1-workflows for old nipype.workflows imports

### DIFF
--- a/sdcflows/workflows/fmap.py
+++ b/sdcflows/workflows/fmap.py
@@ -20,7 +20,7 @@ of the BIDS specification.
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu, fsl, ants
-from nipype.workflows.dmri.fsl.utils import demean_image, cleanup_edge_pipeline
+from niflow.nipype1.workflows.dmri.fsl.utils import demean_image, cleanup_edge_pipeline
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.bids import DerivativesDataSink
 from niworkflows.interfaces.images import IntraModalMerge

--- a/sdcflows/workflows/phdiff.py
+++ b/sdcflows/workflows/phdiff.py
@@ -20,7 +20,7 @@ Fieldmap preprocessing workflow for fieldmap data structure
 
 from nipype.interfaces import ants, fsl, utility as niu
 from nipype.pipeline import engine as pe
-from nipype.workflows.dmri.fsl.utils import siemens2rads, demean_image, \
+from niflow.nipype1.workflows.dmri.fsl.utils import siemens2rads, demean_image, \
     cleanup_edge_pipeline
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.images import IntraModalMerge
@@ -36,7 +36,7 @@ def init_phdiff_wf(omp_nthreads, name='phdiff_wf'):
     Estimates the fieldmap using a phase-difference image and one or more
     magnitude images corresponding to two or more :abbr:`GRE (Gradient Echo sequence)`
     acquisitions. The `original code was taken from nipype
-    <https://github.com/nipy/nipype/blob/master/nipype/workflows/dmri/fsl/artifacts.py#L514>`_.
+    <https://github.com/nipy/nipype/blob/0.12.1/nipype/workflows/dmri/fsl/artifacts.py#L514>`_.
 
     .. workflow ::
         :graph2use: orig

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ setup_requires =
 install_requires =
     nibabel >=2.2.1
     nipype >=1.2.0
+    niflow-nipype1-workflows ~=0.0.1
     niworkflows ~=0.10
     numpy
     pybids ~=0.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ setup_requires =
     setuptools >=40.8
 install_requires =
     nibabel >=2.2.1
-    nipype >=1.2.0
+    nipype >=1.2.0,!=1.2.3
     niflow-nipype1-workflows ~=0.0.1
     niworkflows ~=0.10
     numpy


### PR DESCRIPTION
This should work without requiring a new nipype, but is *required* to use nipype 1.3.0-rc1 or higher.