### PR TITLE
ENH: Base implementation for phase1/2 fieldmaps

### DIFF
--- a/sdcflows/workflows/tests/test_phdiff.py
+++ b/sdcflows/workflows/tests/test_phdiff.py
@@ -14,17 +14,23 @@ def test_phdiff(bids_layouts, tmpdir, output_path, dataset, workdir):
     """Test creation of the workflow."""
     tmpdir.chdir()
 
+    extra_entities = {}
+    if dataset == 'ds001600':
+        extra_entities['acquisition'] = 'v4'
+
     data = bids_layouts[dataset]
     wf = Workflow(name='phdiff_%s' % dataset)
     phdiff_wf = init_phdiff_wf(omp_nthreads=2)
     phdiff_wf.inputs.inputnode.magnitude = data.get(
         suffix=['magnitude1', 'magnitude2'],
-        acquisition='v4',
         return_type='file',
-        extension=['.nii', '.nii.gz'])
+        extension=['.nii', '.nii.gz'],
+        **extra_entities)
 
-    phdiff_files = data.get(suffix='phasediff', acquisition='v4',
-                            extension=['.nii', '.nii.gz'])
+    phdiff_files = data.get(
+        suffix='phasediff',
+        extension=['.nii', '.nii.gz'],
+        **extra_entities)
 
     phdiff_wf.inputs.inputnode.phasediff = [
         (ph.path, ph.get_metadata()) for ph in phdiff_files]

--- a/sdcflows/workflows/tests/test_phdiff.py
+++ b/sdcflows/workflows/tests/test_phdiff.py
@@ -10,7 +10,7 @@ from ..phdiff import init_phdiff_wf, Workflow
     'ds001600',
     'testdata',
 ])
-def test_workflow(bids_layouts, tmpdir, output_path, dataset, workdir):
+def test_phdiff(bids_layouts, tmpdir, output_path, dataset, workdir):
     """Test creation of the workflow."""
     tmpdir.chdir()
 
@@ -19,11 +19,56 @@ def test_workflow(bids_layouts, tmpdir, output_path, dataset, workdir):
     phdiff_wf = init_phdiff_wf(omp_nthreads=2)
     phdiff_wf.inputs.inputnode.magnitude = data.get(
         suffix=['magnitude1', 'magnitude2'],
-        acq='v4',
+        acquisition='v4',
         return_type='file',
         extension=['.nii', '.nii.gz'])
 
-    phdiff_files = data.get(suffix='phasediff', acq='v4',
+    phdiff_files = data.get(suffix='phasediff', acquisition='v4',
+                            extension=['.nii', '.nii.gz'])
+
+    phdiff_wf.inputs.inputnode.phasediff = [
+        (ph.path, ph.get_metadata()) for ph in phdiff_files]
+
+    if output_path:
+        from ...interfaces.reportlets import FieldmapReportlet
+        rep = pe.Node(FieldmapReportlet(reference_label='Magnitude'), 'simple_report')
+        rep.interface._always_run = True
+
+        dsink = pe.Node(DerivativesDataSink(
+            base_directory=str(output_path), keep_dtype=True), name='dsink')
+        dsink.interface.out_path_base = 'sdcflows'
+        dsink.inputs.source_file = phdiff_files[0].path
+
+        wf.connect([
+            (phdiff_wf, rep, [
+                ('outputnode.fmap', 'fieldmap'),
+                ('outputnode.fmap_ref', 'reference'),
+                ('outputnode.fmap_mask', 'mask')]),
+            (rep, dsink, [('out_report', 'in_file')]),
+        ])
+    else:
+        wf.add_nodes([phdiff_wf])
+
+    if workdir:
+        wf.base_dir = str(workdir)
+
+    wf.run()
+
+
+def test_phases(bids_layouts, tmpdir, output_path, workdir):
+    """Test creation of the workflow."""
+    tmpdir.chdir()
+
+    data = bids_layouts['ds001600']
+    wf = Workflow(name='phases_ds001600')
+    phdiff_wf = init_phdiff_wf(omp_nthreads=2)
+    phdiff_wf.inputs.inputnode.magnitude = data.get(
+        suffix=['magnitude1', 'magnitude2'],
+        acquisition='v2',
+        return_type='file',
+        extension=['.nii', '.nii.gz'])
+
+    phdiff_files = data.get(suffix=['phase1', 'phase2'], acquisition='v2',
                             extension=['.nii', '.nii.gz'])
 
     phdiff_wf.inputs.inputnode.phasediff = [

--- a/sdcflows/workflows/tests/test_phdiff.py
+++ b/sdcflows/workflows/tests/test_phdiff.py
@@ -45,12 +45,18 @@ def test_phdiff(bids_layouts, tmpdir, output_path, dataset, workdir):
         dsink.interface.out_path_base = 'sdcflows'
         dsink.inputs.source_file = phdiff_files[0].path
 
+        dsink_fmap = pe.Node(DerivativesDataSink(
+            base_directory=str(output_path), keep_dtype=True), name='dsink_fmap')
+        dsink_fmap.interface.out_path_base = 'sdcflows'
+        dsink_fmap.inputs.source_file = phdiff_files[0].path
+
         wf.connect([
             (phdiff_wf, rep, [
                 ('outputnode.fmap', 'fieldmap'),
                 ('outputnode.fmap_ref', 'reference'),
                 ('outputnode.fmap_mask', 'mask')]),
             (rep, dsink, [('out_report', 'in_file')]),
+            (phdiff_wf, dsink_fmap, [('outputnode.fmap', 'in_file')]),
         ])
     else:
         wf.add_nodes([phdiff_wf])
@@ -90,12 +96,18 @@ def test_phases(bids_layouts, tmpdir, output_path, workdir):
         dsink.interface.out_path_base = 'sdcflows'
         dsink.inputs.source_file = phdiff_files[0].path
 
+        dsink_fmap = pe.Node(DerivativesDataSink(
+            base_directory=str(output_path), keep_dtype=True), name='dsink_fmap')
+        dsink_fmap.interface.out_path_base = 'sdcflows'
+        dsink_fmap.inputs.source_file = phdiff_files[0].path
+
         wf.connect([
             (phdiff_wf, rep, [
                 ('outputnode.fmap', 'fieldmap'),
                 ('outputnode.fmap_ref', 'reference'),
                 ('outputnode.fmap_mask', 'mask')]),
             (rep, dsink, [('out_report', 'in_file')]),
+            (phdiff_wf, dsink_fmap, [('outputnode.fmap', 'in_file')]),
         ])
     else:
         wf.add_nodes([phdiff_wf])


### PR DESCRIPTION
Putting together the lessons learned in #30, leveraging #52 and #53 (unfolded from #30 too), and utilizing #50 and #51, this workflow adds the phase difference map calculation, considering it one use-case of the general phase-difference fieldmap workflow.

On top of this PR, we can continue the discussions held in #30. Probably, we will want to address #23 the first - the magnitude segmentation is sometimes really bad (e.g. see [the phase1/2 unit test](https://298-189292208-gh.circle-artifacts.com/0/tmp/tests/sdcflows/sub-1/fmap/sub-1_acq-v2_phase1.svg)).

Another discussion arisen in #30 is the spatial smoothing of the fieldmap (#22).

Finally, the plan is to revise this implementation and determine whether the subtraction should happen before or after PRELUDE, and whether the arctan2 route is more interesting (#59).