### PR TITLE
Subtract phases before unwrapping

### DIFF
--- a/sdcflows/interfaces/fmap.py
+++ b/sdcflows/interfaces/fmap.py
@@ -706,6 +706,10 @@ def _subtract_phases(in_phases, in_meta, newpath=None):
     sub_data = in_phases_nii[1].get_fdata(dtype='float32') - \
         in_phases_nii[0].get_fdata(dtype='float32')
 
+    # wrap negative radians back to [0, 2pi]
+    sub_data[sub_data < 0] += 2 * np.pi
+    sub_data = np.clip(sub_data, 0.0, 2 * np.pi)
+
     new_meta = in_meta[1].copy()
     new_meta.update(in_meta[0])
     new_meta['EchoTime1'] = echo_times[0]

--- a/sdcflows/workflows/phdiff.py
+++ b/sdcflows/workflows/phdiff.py
@@ -105,7 +105,7 @@ and further improvements in HCP Pipelines [@hcppipelines].
     phmap2rads = pe.MapNode(PhaseMap2rads(), name='phmap2rads',
                             iterfield=['in_file'], run_without_submitting=True)
     # FSL PRELUDE will perform phase-unwrapping
-    prelude = pe.MapNode(fsl.PRELUDE(), iterfield=['phase_file'], name='prelude')
+    prelude = pe.Node(fsl.PRELUDE(), name='prelude')
 
     calc_phdiff = pe.Node(SubtractPhases(), name='calc_phdiff',
                           run_without_submitting=True)

--- a/sdcflows/workflows/phdiff.py
+++ b/sdcflows/workflows/phdiff.py
@@ -120,12 +120,11 @@ and further improvements in HCP Pipelines [@hcppipelines].
         (magnitude_wf, prelude, [('outputnode.fmap_ref', 'magnitude_file'),
                                  ('outputnode.fmap_mask', 'mask_file')]),
         (split, phmap2rads, [('map_file', 'in_file')]),
-        (phmap2rads, prelude, [('out_file', 'phase_file')]),
-        (prelude, calc_phdiff, [('unwrapped_phase_file', 'in_phases')]),
+        (phmap2rads, calc_phdiff, [('out_file', 'in_phases')]),
         (split, calc_phdiff, [('meta', 'in_meta')]),
-        (calc_phdiff, fmap_postproc_wf, [
-            ('phase_diff', 'inputnode.fmap'),
-            ('metadata', 'inputnode.metadata')]),
+        (calc_phdiff, prelude, [('phase_diff', 'phase_file')]),
+        (prelude, fmap_postproc_wf, [('unwrapped_phase_file', 'inputnode.fmap')]),
+        (calc_phdiff, fmap_postproc_wf, [('metadata', 'inputnode.metadata')]),
         (magnitude_wf, fmap_postproc_wf, [
             ('outputnode.fmap_mask', 'inputnode.fmap_mask'),
             ('outputnode.fmap_ref', 'inputnode.fmap_ref')]),


### PR DESCRIPTION
Swapped order of subtract/unwrap. Due to how PRELUDE algorithm works, this should create the same results in most cases and produce smoother phasediff map in some cases that are problematic currently.

https://github.com/poldracklab/sdcflows/pull/30#issuecomment-555881469
https://github.com/poldracklab/sdcflows/issues/59