### PR TITLE
FIX: ValueError when one of the PEPOLAR fielmaps is not 4D

### DIFF
--- a/sdcflows/workflows/pepolar.py
+++ b/sdcflows/workflows/pepolar.py
@@ -365,7 +365,10 @@ def _split_epi_lists(in_files, pe_dir, max_trs=50):
 
     for i, (epi_path, epi_pe) in enumerate(in_files):
         if epi_pe[0] == pe_dir[0]:
-            splitnii = nb.four_to_three(nb.load(epi_path))[:max_trs]
+            try:
+                splitnii = nb.four_to_three(nb.load(epi_path))[:max_trs]
+            except ValueError:
+                splitnii = [nb.load(epi_path)]
 
             for j, nii in enumerate(splitnii):
                 out_name = op.abspath(


### PR DESCRIPTION
The idea here was to avoid loading the whole image into memory to extract the first `max_trs` volumes at most. @effigies, is this the better way of doing this?

Addresses #73 