### PR TITLE
FIX: Flexibly and cheaply select initial PEPOLAR volumes

### DIFF
--- a/sdcflows/workflows/pepolar.py
+++ b/sdcflows/workflows/pepolar.py
@@ -365,7 +365,11 @@ def _split_epi_lists(in_files, pe_dir, max_trs=50):
 
     for i, (epi_path, epi_pe) in enumerate(in_files):
         if epi_pe[0] == pe_dir[0]:
-            splitnii = nb.four_to_three(nb.load(epi_path))[:max_trs]
+            img = nb.load(epi_path)
+            if len(img.shape) == 3:
+                splitnii = [img]
+            else:
+                splitnii = nb.four_to_three(img.slicer[:, :, :, :max_trs])
 
             for j, nii in enumerate(splitnii):
                 out_name = op.abspath(

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.5
 setup_requires =
     setuptools >=40.8
 install_requires =
-    nibabel >=2.2.1
+    nibabel >=2.3
     niflow-nipype1-workflows ~= 0.0.1
     nipype >= 1.3.1
     niworkflows ~= 1.0.0


### PR DESCRIPTION
In nibabel 2.3+, we can use `img.slicer` to cheaply select slices of images, in this case a number of volumes. This reduces the memory overhead of `four_to_three`, which will create an image for every volume. (In context, I doubt this was a significant overhead.)

This also fixes #73, where single volume files were breaking `four_to_three`'s assumption of 4 dimensions.

Closes #74.