### PR TITLE
pin: latest niworkflows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     nibabel >=2.3
     niflow-nipype1-workflows ~= 0.0.1
     nipype >= 1.3.1
-    niworkflows ~= 1.0.0
+    niworkflows ~= 1.1.0
     numpy
     pybids ~=0.9.2
     templateflow ~= 0.4


### PR DESCRIPTION
spotted when building fMRIPrep docker image:

```
ERROR: sdcflows 1.0.1 has requirement niworkflows~=1.0.0, but you'll have niworkflows 1.1.0 which is incompatible.
```