### PR TITLE
FIX: NiWorkflows' ``IntraModalMerge`` choked with images of shape (x, y, z, 1)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     nibabel >=2.3
     niflow-nipype1-workflows ~= 0.0.1
     nipype >= 1.3.1
-    niworkflows @ git+https://github.com/poldracklab/niworkflows.git@4b310a139356f7cfed6e40b299ced9fecfe3daf0
+    niworkflows ~= 1.1.1
     numpy
     pybids ~=0.9.2
     templateflow ~= 0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     nibabel >=2.3
     niflow-nipype1-workflows ~= 0.0.1
     nipype >= 1.3.1
-    niworkflows ~= 1.0.0
+    niworkflows @ git+https://github.com/poldracklab/niworkflows.git@4b310a139356f7cfed6e40b299ced9fecfe3daf0
     numpy
     pybids ~=0.9.2
     templateflow ~= 0.4


### PR DESCRIPTION
After revising the workflow design, everything looked good (so I stand
corrected - have scratched text accordingly in the bug report).

Just an update of niworkflows will be necessary. Replaces and closes #78.

Close #77.