### PR TITLE
REL: 1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-name = sdcflows
 url = https://github.com/poldracklab/sdcflows
 author = The SDCflows developers
 author_email = code@oscaresteban.es

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     nibabel >=2.4.1
     niflow-nipype1-workflows ~= 0.0.1
     nipype >=1.3.1
-    niworkflows ~= 1.0.3
+    niworkflows ~= 1.1.4
     numpy
     pybids ~= 0.9.2
     templateflow >=0.4

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def main():
     cmdclass = versioneer.get_cmdclass()
 
     setup(
+        name='sdcflows',
         version=__version__,
         cmdclass=cmdclass,
         download_url=DOWNLOAD_URL,


### PR DESCRIPTION
When installing `fmriprep` from the repository, I get:

```
ERROR: sdcflows 1.0.4 has requirement niworkflows~=1.0.3, but you'll have niworkflows 1.1.4 which is incompatible.
```

To ensure that `~=` constraints keep a compatible batch of releases, I propose that we start a 1.1.x series that depends on `niworkflows ~=1.1.4`.

If bug fixes are needed with 1.0.x, we can create a maintenance branch.

I've also moved the `name` metadata to `setup.py`, which allows GitHub's dependency tree to find sdcflows.