### PR TITLE
MAINT: Flexibilize dependencies -- nipype, niworkflows, pybids

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nibabel >=3.0.1
     niflow-nipype1-workflows ~= 0.0.1
     nipype >=1.3.1,<2.0
-    niworkflows >= 1.1.4
+    niworkflows >=1.1.4,<1.3
     numpy
     pybids >= 0.9.2
     templateflow >=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,6 @@
 [metadata]
-url = https://github.com/nipreps/sdcflows
 author = The SDCflows developers
 author_email = nipreps@gmail.com
-maintainer = Oscar Esteban
-maintainer_email = nipreps@gmail.com
-description = Susceptibility Distortion Correction (SDC) workflows for EPI MR schemes.
-long_description = file:README.rst
-long_description_content_type = text/x-rst; charset=UTF-8
-license = Apache-2.0
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Science/Research
@@ -16,18 +9,27 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+description = Susceptibility Distortion Correction (SDC) workflows for EPI MR schemes.
+license = Apache-2.0
+long_description = file:README.rst
+long_description_content_type = text/x-rst; charset=UTF-8
+project_urls =
+    Documentation = https://www.nipreps.org/sdcflows
+    GitHub = https://github.com/nipreps/sdcflows
+    fMRIPrep = https://fmriprep.readthedocs.io
+url = https://www.nipreps.org/sdcflows
 
 [options]
 python_requires = >=3.5
 setup_requires =
     setuptools >=40.8
 install_requires =
-    nibabel >=2.4.1
+    nibabel >=3.0.1
     niflow-nipype1-workflows ~= 0.0.1
-    nipype >=1.3.1
-    niworkflows ~= 1.1.4
+    nipype >=1.3.1,<2.0
+    niworkflows >= 1.1.4
     numpy
-    pybids ~= 0.9.2
+    pybids >= 0.9.2
     templateflow >=0.4
 test_requires =
     codecov


### PR DESCRIPTION
These changes will make it easier to implement the table in poldracklab/fmriprep#2054.

It also curates a bit the package metadata, now that I was at it.

References: poldracklab/fmriprep#2054