### PR TITLE
FIX: Do not reorient magnitude images

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ packaging
 pydot>=1.2.3
 pydotplus
 sphinx-argparse
-sphinx>=2.1.2
+sphinx>=2.1.2,<3
 sphinx_rtd_theme
 sphinxcontrib-apidoc ~= 0.3.0
 templateflow

--- a/sdcflows/workflows/gre.py
+++ b/sdcflows/workflows/gre.py
@@ -65,7 +65,8 @@ def init_magnitude_wf(omp_nthreads, name='magnitude_wf'):
         name='outputnode')
 
     # Merge input magnitude images
-    magmrg = pe.Node(IntraModalMerge(hmc=False), name='magmrg')
+    # Do not reorient to RAS to preserve the validity of PhaseEncodingDirection
+    magmrg = pe.Node(IntraModalMerge(hmc=False, to_ras=False), name='magmrg')
 
     # de-gradient the fields ("bias/illumination artifact")
     n4_correct = pe.Node(ants.N4BiasFieldCorrection(dimension=3, copy_header=True),

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ include_package_data = True
 
 [options.extras_require]
 doc =
-    sphinx >= 2.1.2
+    sphinx >= 2.1.2, <3
     pydot >= 1.2.3
     pydotplus
     sphinx_rtd_theme


### PR DESCRIPTION
In #33 it is shown that fieldmaps in AIL orientation produce an error in `sdc_estimate_wf.phdiff_wf.fmap_postproc_wf.cleanup_wf.Despike` where the brainmask generated in `sdc_estimate_wf.phdiff_wf.magnitude_wf.bet` is in a different orientation.

This is because the input to BET is reoriented to RAS in the `magmrg` step. I considered forcing all images to RAS, but that has the potential to cause problems with `PhaseEncodingDirection`, which is one of the voxel dimensions `i`, `j`, and `k`, and not coded in RAS space.

The simpler solution is simply not to reorient images during this workflow, to ensure that calculations are performed as intended. A further validation step could ensure that all fieldmap images have the same orientation and voxel sizes, but that would be a more significant change.

Because this is a change to an interface input, workflow directories can be reused without clearing. This can be safely included in the 1.5.x series of fMRIPrep.

Fixes #33.