### PR TITLE
FIX: WM mask selection from dseg before generating report

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/rwblair/sphinxcontrib-versioning.git@39b40b0b84bf872fc398
 nbsphinx
 niflow-nipype1-workflows ~= 0.0.1
 nipype>=1.3.1
-niworkflows ~= 1.1.2
+niworkflows >=1.2.0rc4,<1.4
 packaging
 pydot>=1.2.3
 pydotplus

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -43,7 +43,7 @@ def init_sdc_unwarp_report_wf(name='sdc_unwarp_report_wf', forcedsyn=False):
     """
     from niworkflows.interfaces import SimpleBeforeAfter
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
-    from niworkflows.interfaces.images import extract_wm
+    from niworkflows.utils.images import dseg_label as _dseg_label
 
     DEFAULT_MEMORY_MIN_GB = 0.01
 
@@ -56,8 +56,9 @@ def init_sdc_unwarp_report_wf(name='sdc_unwarp_report_wf', forcedsyn=False):
         dimension=3, float=True, interpolation='MultiLabel'),
         name='map_seg', mem_gb=0.3)
 
-    sel_wm = pe.Node(niu.Function(function=extract_wm), name='sel_wm',
+    sel_wm = pe.Node(niu.Function(function=_dseg_label), name='sel_wm',
                      mem_gb=DEFAULT_MEMORY_MIN_GB)
+    sel_wm.inputs.label = 2
 
     bold_rpt = pe.Node(SimpleBeforeAfter(), name='bold_rpt',
                        mem_gb=0.1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     nibabel >=3.0.1
     niflow-nipype1-workflows ~= 0.0.1
     nipype >=1.3.1,<2.0
-    niworkflows >=1.1.4,<1.3
+    niworkflows >=1.2.0rc4,<1.4
     numpy
     pybids >= 0.9.2
     templateflow >=0.4


### PR DESCRIPTION
Following suit of poldracklab/fmriprep#2084 and inline with nipreps/niworkflows#500, this PR uses a more robust version of the extraction code.

Resolves: #99
Depends: nipreps/niworkflows#500