### PR TITLE
SDC-pepolar: topup implementation v2

### DIFF
--- a/sdcflows/workflows/pepolar.py
+++ b/sdcflows/workflows/pepolar.py
@@ -95,7 +95,7 @@ def init_pepolar_wf(omp_nthreads=1, matched_pe=False, name="pepolar_wf"):
 A B0-nonuniformity map (or *fieldmap*) was estimated based on two (or more)
 echo-planar imaging (EPI) references of opposed phase-encoding
 directions, with `topup` @topup (FSL {fsl_ver}).
-""".format(fsl_ver=''.join(['%02d' % v for v in fsl.Info().version() or []]))
+""".format(fsl_ver=fsl.Info().version())
 
     inputnode = pe.Node(niu.IdentityInterface(
         fields=['fmaps_epi', 'epi_pe_dir', 'epi_trt', 'in_reference', 'matched_pe_dir',


### PR DESCRIPTION
Ref #37

Decided to do this as a new PR as the initial comments to #76 required implementing the approach somewhat differently. 

`pepolar.py` is now modified to run fsl topup. `pepolar.py` returns a topup estimated fieldmap (in Hz) and a "magnitude" image (the unwarped epis from topup).

Next, the topup estimated fieldmap is converted to a displacement field using routines from the `sdcflows.workflows.fmap` module (`fmap_wf` + `fmap2field_wf`).

Finally, unwarping is performed using the `sdcflow_workflows.unwarp` module.