### PR TITLE
FIX: Convert SEI fieldmaps given in rad/s into Hz

### DIFF
--- a/sdcflows/interfaces/fmap.py
+++ b/sdcflows/interfaces/fmap.py
@@ -1,7 +1,9 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces to deal with the various types of fieldmap sources."""
-
+import numpy as np
+import nibabel as nb
+from nipype.utils.filemanip import fname_presuffix
 from nipype import logging
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
@@ -98,4 +100,32 @@ class Phasediff2Fieldmap(SimpleInterface):
         self._results["out_file"] = phdiff2fmap(
             self.inputs.in_file, _delta_te(self.inputs.metadata), newpath=runtime.cwd
         )
+        return runtime
+
+
+class _CheckB0UnitsInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="input fieldmap")
+    units = traits.Enum("Hz", "rad/s", mandatory=True, desc="fieldmap units")
+
+
+class _CheckB0UnitsOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc="output fieldmap in Hz")
+
+
+class CheckB0Units(SimpleInterface):
+    """Ensure the input fieldmap is given in Hz."""
+
+    input_spec = _CheckB0UnitsInputSpec
+    output_spec = _CheckB0UnitsOutputSpec
+
+    def _run_interface(self, runtime):
+        if self.inputs.units == "Hz":
+            self._results["out_file"] = self.inputs.in_file
+            return runtime
+
+        self._results["out_file"] = fname_presuffix(
+            self.inputs.in_file, suffix="_Hz", newpath=runtime.cwd)
+        img = nb.load(self.inputs.in_file)
+        data = np.asanyarray(img.dataobj) / (2.0 * np.pi)
+        img.__class__(data, img.affine, img.header).to_filename(self._results["out_file"])
         return runtime

--- a/sdcflows/interfaces/fmap.py
+++ b/sdcflows/interfaces/fmap.py
@@ -124,8 +124,11 @@ class CheckB0Units(SimpleInterface):
             return runtime
 
         self._results["out_file"] = fname_presuffix(
-            self.inputs.in_file, suffix="_Hz", newpath=runtime.cwd)
+            self.inputs.in_file, suffix="_Hz", newpath=runtime.cwd
+        )
         img = nb.load(self.inputs.in_file)
         data = np.asanyarray(img.dataobj) / (2.0 * np.pi)
-        img.__class__(data, img.affine, img.header).to_filename(self._results["out_file"])
+        img.__class__(data, img.affine, img.header).to_filename(
+            self._results["out_file"]
+        )
         return runtime

--- a/sdcflows/interfaces/tests/test_fmap.py
+++ b/sdcflows/interfaces/tests/test_fmap.py
@@ -1,0 +1,24 @@
+"""Test fieldmap interfaces."""
+import numpy as np
+import nibabel as nb
+import pytest
+
+from ..fmap import CheckB0Units
+
+
+@pytest.mark.parametrize("units", ("rad/s", "Hz"))
+def test_units(tmpdir, units):
+    """Check the conversion of units."""
+    tmpdir.chdir()
+    hz = np.ones((5, 5, 5), dtype="float32") * 100
+    data = hz.copy()
+
+    if units == "rad/s":
+        data *= 2.0 * np.pi
+
+    nb.Nifti1Image(data, np.eye(4), None).to_filename("data.nii.gz")
+    out_data = nb.load(
+        CheckB0Units(units=units, in_file="data.nii.gz").run().outputs.out_file
+    ).get_fdata(dtype="float32")
+
+    assert np.allclose(hz, out_data)


### PR DESCRIPTION
Adds a lightweight node (`run_without_submitting=True`) wrapping an interface
that just checks the units of the input image and divides by 2pi when units
are rad/s. Unfortunatelly, we don't currently have data to test these fieldmaps.

Resolves: #124.