### PR TITLE
ENH: Keep a registry of already-used identifiers (and auto-generate new)

### DIFF
--- a/sdcflows/tests/test_fieldmaps.py
+++ b/sdcflows/tests/test_fieldmaps.py
@@ -54,9 +54,28 @@ def test_FieldmapEstimation(testdata_dir, inputfiles, method, nsources):
     """Test errors."""
     sub_dir = testdata_dir / "sub-01"
 
-    fe = FieldmapEstimation([sub_dir / f for f in inputfiles])
+    sources = [sub_dir / f for f in inputfiles]
+    fe = FieldmapEstimation(sources)
     assert fe.method == method
     assert len(fe.sources) == nsources
+    assert fe.bids_id is not None and fe.bids_id.startswith("auto_")
+
+    # Attempt to change bids_id
+    with pytest.raises(ValueError):
+        fe.bids_id = "other"
+
+    # Setting the same value should not raise
+    fe.bids_id = fe.bids_id
+
+    # Ensure duplicate B0FieldIdentifier are not accepted
+    with pytest.raises(ValueError):
+        FieldmapEstimation(sources, bids_id=fe.bids_id)
+
+    # B0FieldIdentifier can be generated manually
+    # Creating two FieldmapEstimation objects from the same sources SHOULD fail
+    # or be better handled in the future (see #129).
+    fe2 = FieldmapEstimation(sources, bids_id=f"no{fe.bids_id}")
+    assert fe2.bids_id and fe2.bids_id.startswith("noauto_")
 
 
 @pytest.mark.parametrize(
@@ -74,3 +93,38 @@ def test_FieldmapEstimationError(testdata_dir, inputfiles, errortype):
 
     with pytest.raises(errortype):
         FieldmapEstimation([sub_dir / f for f in inputfiles])
+
+
+def test_FieldmapEstimationIdentifier(testdata_dir):
+    """Check some use cases of B0FieldIdentifier."""
+    with pytest.raises(ValueError):
+        FieldmapEstimation([
+            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
+            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"})
+        ])  # Inconsistent identifiers
+
+    fe = FieldmapEstimation([
+        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
+        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"})
+    ])
+    assert fe.bids_id == "fmap_0"
+
+    with pytest.raises(ValueError):
+        FieldmapEstimation([
+            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
+            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"})
+        ])  # Consistent, but already exists
+
+    fe = FieldmapEstimation([
+        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"}),
+        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"})
+    ])
+    assert fe.bids_id == "fmap_1"

--- a/sdcflows/utils/phasemanip.py
+++ b/sdcflows/utils/phasemanip.py
@@ -108,7 +108,7 @@ def delta_te(in_values):
     >>> delta_te({})  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ValueError:
-    
+
     >>> delta_te({"EchoTimeDifference": "a"})  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ValueError:

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -41,20 +41,20 @@ def init_fmap_preproc_wf(
     ...     omp_nthreads=1,
     ...     output_dir="/tmp",
     ...     subject="1",
-    ... )
-    [FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>),
-     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>),
-     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>)]
+    ... )  # doctest: +ELLIPSIS
+    [FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
+     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
+     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
 
     >>> init_fmap_preproc_wf(
     ...     layout=layouts['testdata'],
     ...     omp_nthreads=1,
     ...     output_dir="/tmp",
     ...     subject="HCP101006",
-    ... )
-    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PHASEDIFF: 3>),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>)]
+    ... )  # doctest: +ELLIPSIS
+    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
 
     """
     from ..fieldmaps import FieldmapEstimation, FieldmapFile


### PR DESCRIPTION
This is the projection of the ``B0FieldIdentifier`` metadata proposed for the BIDS spec. Having an identifier for each estimation strategy is the most robust way of minimizing the computational load and reliably keep track of fieldmap information. 

Followed-up-by: #129.
Resolves: #125.