### PR TITLE
MAINT: Migrate test datasets to a datalad+osf infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
             - env-v2-
       - restore_cache:
           keys:
-            - data-v2-{{ .Branch }}-
-            - data-v2-master-
-            - data-v2-
+            - data-v3-{{ .Branch }}-
+            - data-v3-master-
+            - data-v3-
 
       - run:
           name: Setup git-annex
@@ -67,7 +67,7 @@ jobs:
           name: Setup DataLad & TemplateFlow
           command: |
             python -m pip install --no-cache-dir -U pip
-            python -m pip install --no-cache-dir -U datalad
+            python -m pip install --no-cache-dir -U datalad datalad-osf
             python -m pip install --no-cache-dir -U templateflow
             python -c "from templateflow import api as tfapi; \
                        tfapi.get('MNI152NLin2009cAsym', resolution=2, desc='brain', suffix='mask'); \
@@ -89,16 +89,23 @@ jobs:
             datalad install https://github.com/OpenNeuroDatasets/ds001600.git
             datalad update --merge -d ds001600/
             datalad get -r -d ds001600/
+
       - run:
-          name: Get testdata
+          name: Install HCP/sub-101006
           command: |
-            if [[ ! -d /tmp/data/testdata ]]; then
-              wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q \
-                  -O testdata.zip "https://files.osf.io/v1/resources/9sy2a/providers/osfstorage/5d44b940bcd6d900198ed6be/?zip="
-              unzip testdata.zip -d /tmp/data/testdata
-            fi
+            datalad install -r https://github.com/nipreps-data/HCP101006.git
+            datalad update -r --merge -d HCP101006/
+            datalad get -r -d HCP101006
+
+      - run:
+          name: Install ds001771
+          command: |
+            datalad install -r https://github.com/nipreps-data/ds001771.git
+            datalad update --merge -d ds001771/
+            datalad get -r -d ds001771/ ds001771/sub-36/fmap/*
+
       - save_cache:
-          key: data-v2-{{ .Branch }}-{{ .BuildNum }}
+          key: data-v3-{{ .Branch }}-{{ .BuildNum }}
           paths:
             - /tmp/data
             - /tmp/templateflow
@@ -241,9 +248,9 @@ jobs:
             - freesurfer-v1-
       - restore_cache:
           keys:
-            - data-v2-{{ .Branch }}-
-            - data-v2-master-
-            - data-v2-
+            - data-v3-{{ .Branch }}-
+            - data-v3-master-
+            - data-v3-
       - restore_cache:
           keys:
             - workdir-v2-{{ .Branch }}-

--- a/sdcflows/workflows/apply/tests/test_correct.py
+++ b/sdcflows/workflows/apply/tests/test_correct.py
@@ -15,18 +15,18 @@ def test_unwarp_wf(tmpdir, datadir, workdir, outdir):
     """Test the unwarping workflow."""
     distorted = (
         datadir
-        / "testdata"
-        / "sub-HCP101006"
+        / "HCP101006"
+        / "sub-101006"
         / "func"
-        / "sub-HCP101006_task-rest_dir-LR_sbref.nii.gz"
+        / "sub-101006_task-rest_dir-LR_sbref.nii.gz"
     )
 
     magnitude = (
         datadir
-        / "testdata"
-        / "sub-HCP101006"
+        / "HCP101006"
+        / "sub-101006"
         / "fmap"
-        / "sub-HCP101006_magnitude1.nii.gz"
+        / "sub-101006_magnitude1.nii.gz"
     )
     fmap_ref_wf = init_magnitude_wf(2, name="fmap_ref_wf")
     fmap_ref_wf.inputs.inputnode.magnitude = magnitude

--- a/sdcflows/workflows/apply/tests/test_registration.py
+++ b/sdcflows/workflows/apply/tests/test_registration.py
@@ -15,18 +15,18 @@ def test_registration_wf(tmpdir, datadir, workdir, outdir):
     epi_ref_wf = init_magnitude_wf(2, name="epi_ref_wf")
     epi_ref_wf.inputs.inputnode.magnitude = (
         datadir
-        / "testdata"
-        / "sub-HCP101006"
+        / "HCP101006"
+        / "sub-101006"
         / "func"
-        / "sub-HCP101006_task-rest_dir-LR_sbref.nii.gz"
+        / "sub-101006_task-rest_dir-LR_sbref.nii.gz"
     )
 
     magnitude = (
         datadir
-        / "testdata"
-        / "sub-HCP101006"
+        / "HCP101006"
+        / "sub-101006"
         / "fmap"
-        / "sub-HCP101006_magnitude1.nii.gz"
+        / "sub-101006_magnitude1.nii.gz"
     )
     fmap_ref_wf = init_magnitude_wf(2, name="fmap_ref_wf")
     fmap_ref_wf.inputs.inputnode.magnitude = magnitude

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -48,10 +48,10 @@ def init_fmap_preproc_wf(
      FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
 
     >>> init_fmap_preproc_wf(
-    ...     layout=layouts['testdata'],
+    ...     layout=layouts['HCP101006'],
     ...     omp_nthreads=1,
     ...     output_dir="/tmp",
-    ...     subject="HCP101006",
+    ...     subject="101006",
     ... )  # doctest: +ELLIPSIS
     [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
      FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]

--- a/sdcflows/workflows/fit/tests/test_pepolar.py
+++ b/sdcflows/workflows/fit/tests/test_pepolar.py
@@ -18,8 +18,8 @@ from ..pepolar import init_topup_wf
         #     "ds001600/sub-1/fmap/sub-1_dir-PA_epi.nii.gz",
         # ),
         (
-            "testdata/sub-HCP101006/fmap/sub-HCP101006_dir-LR_epi.nii.gz",
-            "testdata/sub-HCP101006/fmap/sub-HCP101006_dir-RL_epi.nii.gz",
+            "HCP101006/sub-101006/fmap/sub-101006_dir-LR_epi.nii.gz",
+            "HCP101006/sub-101006/fmap/sub-101006_dir-RL_epi.nii.gz",
         ),
     ],
 )

--- a/sdcflows/workflows/fit/tests/test_phdiff.py
+++ b/sdcflows/workflows/fit/tests/test_phdiff.py
@@ -17,7 +17,7 @@ from ..fieldmap import init_fmap_wf, Workflow
             "ds001600/sub-1/fmap/sub-1_acq-v2_phase1.nii.gz",
             "ds001600/sub-1/fmap/sub-1_acq-v2_phase2.nii.gz",
         ),
-        ("testdata/sub-HCP101006/fmap/sub-HCP101006_phasediff.nii.gz",),
+        ("HCP101006/sub-101006/fmap/sub-101006_phasediff.nii.gz",),
     ],
 )
 def test_phdiff(tmpdir, datadir, workdir, outdir, fmap_path):


### PR DESCRIPTION
Allows us to share test data easily across projects, through the
new nipreps-data org.

Of particular interest is ds001771 (originally used in *dMRIPrep*
for testing), because it has some "fieldmap" images that were actually
generated with TOPUP, so we will be able to compare.