### PR TITLE
ENH: Disallow ``FieldmapEstimation`` objects with same sources

### DIFF
--- a/sdcflows/tests/test_fieldmaps.py
+++ b/sdcflows/tests/test_fieldmaps.py
@@ -1,20 +1,22 @@
 """test_fieldmaps."""
 import pytest
-from ..fieldmaps import FieldmapFile, FieldmapEstimation, EstimatorType
+from ..utils.bimap import bidict
+from .. import fieldmaps as fm
 
 
 def test_FieldmapFile(testdata_dir):
     """Test one existing file."""
-    FieldmapFile(testdata_dir / "sub-01" / "anat" / "sub-01_T1w.nii.gz")
+    fm.FieldmapFile(testdata_dir / "sub-01" / "anat" / "sub-01_T1w.nii.gz")
 
 
 @pytest.mark.parametrize(
-    "inputfiles,method,nsources",
+    "inputfiles,method,nsources,raises",
     [
         (
             ("fmap/sub-01_fieldmap.nii.gz", "fmap/sub-01_magnitude.nii.gz"),
-            EstimatorType.MAPPED,
+            fm.EstimatorType.MAPPED,
             2,
+            False,
         ),
         (
             (
@@ -23,39 +25,52 @@ def test_FieldmapFile(testdata_dir):
                 "fmap/sub-01_magnitude1.nii.gz",
                 "fmap/sub-01_magnitude2.nii.gz",
             ),
-            EstimatorType.PHASEDIFF,
+            fm.EstimatorType.PHASEDIFF,
             4,
+            False,
         ),
         (
             ("fmap/sub-01_phase1.nii.gz", "fmap/sub-01_phase2.nii.gz"),
-            EstimatorType.PHASEDIFF,
+            fm.EstimatorType.PHASEDIFF,
             4,
+            True,
         ),
-        (("fmap/sub-01_phase2.nii.gz",), EstimatorType.PHASEDIFF, 4),
-        (("fmap/sub-01_phase1.nii.gz",), EstimatorType.PHASEDIFF, 4),
+        (("fmap/sub-01_phase2.nii.gz",), fm.EstimatorType.PHASEDIFF, 4, True),
+        (("fmap/sub-01_phase1.nii.gz",), fm.EstimatorType.PHASEDIFF, 4, True),
         (
             ("fmap/sub-01_dir-LR_epi.nii.gz", "fmap/sub-01_dir-RL_epi.nii.gz"),
-            EstimatorType.PEPOLAR,
+            fm.EstimatorType.PEPOLAR,
             2,
+            False,
         ),
         (
             ("fmap/sub-01_dir-LR_epi.nii.gz", "dwi/sub-01_dir-RL_sbref.nii.gz"),
-            EstimatorType.PEPOLAR,
+            fm.EstimatorType.PEPOLAR,
             2,
+            False,
         ),
         (
             ("anat/sub-01_T1w.nii.gz", "dwi/sub-01_dir-RL_sbref.nii.gz"),
-            EstimatorType.ANAT,
+            fm.EstimatorType.ANAT,
             2,
+            False,
         ),
     ],
 )
-def test_FieldmapEstimation(testdata_dir, inputfiles, method, nsources):
+def test_FieldmapEstimation(
+    monkeypatch, testdata_dir, inputfiles, method, nsources, raises
+):
     """Test errors."""
     sub_dir = testdata_dir / "sub-01"
 
     sources = [sub_dir / f for f in inputfiles]
-    fe = FieldmapEstimation(sources)
+
+    if raises is True:
+        with pytest.raises(ValueError):
+            fm.FieldmapEstimation(sources)
+        monkeypatch.setattr(fm, "_estimators", bidict())
+
+    fe = fm.FieldmapEstimation(sources)
     assert fe.method == method
     assert len(fe.sources) == nsources
     assert fe.bids_id is not None and fe.bids_id.startswith("auto_")
@@ -68,14 +83,12 @@ def test_FieldmapEstimation(testdata_dir, inputfiles, method, nsources):
     fe.bids_id = fe.bids_id
 
     # Ensure duplicate B0FieldIdentifier are not accepted
-    with pytest.raises(ValueError):
-        FieldmapEstimation(sources, bids_id=fe.bids_id)
+    with pytest.raises(KeyError):
+        fm.FieldmapEstimation(sources, bids_id=fe.bids_id)
 
-    # B0FieldIdentifier can be generated manually
-    # Creating two FieldmapEstimation objects from the same sources SHOULD fail
-    # or be better handled in the future (see #129).
-    fe2 = FieldmapEstimation(sources, bids_id=f"no{fe.bids_id}")
-    assert fe2.bids_id and fe2.bids_id.startswith("noauto_")
+    # Ensure we can't instantiate one more estimation with same sources
+    with pytest.raises(ValueError):
+        fm.FieldmapEstimation(sources, bids_id=f"my{fe.bids_id}")
 
     # Exercise workflow creation
     wf = fe.get_workflow()
@@ -91,44 +104,77 @@ def test_FieldmapEstimation(testdata_dir, inputfiles, method, nsources):
         (("anat/sub-01_T1w.nii.gz", "fmap/sub-01_phase2.nii.gz"), TypeError),
     ],
 )
-def test_FieldmapEstimationError(testdata_dir, inputfiles, errortype):
+def test_FieldmapEstimationError(monkeypatch, testdata_dir, inputfiles, errortype):
     """Test errors."""
     sub_dir = testdata_dir / "sub-01"
 
+    monkeypatch.setattr(fm, "_estimators", bidict())
+
     with pytest.raises(errortype):
-        FieldmapEstimation([sub_dir / f for f in inputfiles])
+        fm.FieldmapEstimation([sub_dir / f for f in inputfiles])
 
 
-def test_FieldmapEstimationIdentifier(testdata_dir):
+def test_FieldmapEstimationIdentifier(monkeypatch, testdata_dir):
     """Check some use cases of B0FieldIdentifier."""
-    with pytest.raises(ValueError):
-        FieldmapEstimation([
-            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
-                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
-            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
-                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"})
-        ])  # Inconsistent identifiers
 
-    fe = FieldmapEstimation([
-        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
-                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
-        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
-                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"})
-    ])
+    monkeypatch.setattr(fm, "_estimators", bidict())
+
+    with pytest.raises(ValueError):
+        fm.FieldmapEstimation(
+            [
+                fm.FieldmapFile(
+                    testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                    metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"},
+                ),
+                fm.FieldmapFile(
+                    testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                    metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"},
+                ),
+            ]
+        )  # Inconsistent identifiers
+
+    fe = fm.FieldmapEstimation(
+        [
+            fm.FieldmapFile(
+                testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"},
+            ),
+            fm.FieldmapFile(
+                testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"},
+            ),
+        ]
+    )
     assert fe.bids_id == "fmap_0"
 
-    with pytest.raises(ValueError):
-        FieldmapEstimation([
-            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
-                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"}),
-            FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
-                         metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"})
-        ])  # Consistent, but already exists
+    with pytest.raises(KeyError):
+        fm.FieldmapEstimation(
+            [
+                fm.FieldmapFile(
+                    testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                    metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"},
+                ),
+                fm.FieldmapFile(
+                    testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                    metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_0"},
+                ),
+            ]
+        )  # Consistent, but already exists
 
-    fe = FieldmapEstimation([
-        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
-                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"}),
-        FieldmapFile(testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
-                     metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"})
-    ])
+    monkeypatch.setattr(fm, "_estimators", bidict())
+
+    fe = fm.FieldmapEstimation(
+        [
+            fm.FieldmapFile(
+                testdata_dir / "sub-01" / "fmap/sub-01_fieldmap.nii.gz",
+                metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"},
+            ),
+            fm.FieldmapFile(
+                testdata_dir / "sub-01" / "fmap/sub-01_magnitude.nii.gz",
+                metadata={"Units": "Hz", "B0FieldIdentifier": "fmap_1"},
+            ),
+        ]
+    )
     assert fe.bids_id == "fmap_1"
+
+    monkeypatch.setattr(fm, "_estimators", bidict())

--- a/sdcflows/utils/bimap.py
+++ b/sdcflows/utils/bimap.py
@@ -56,6 +56,10 @@ class bidict(dict):
     Traceback (most recent call last):
     TypeError: value '[]' of unhashable type: 'list'
 
+    >>> d[list()] = 1  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: key '[]' of unhashable type: 'list'
+
     >>> d.add("a new value")
     'auto_00000'
 
@@ -73,6 +77,14 @@ class bidict(dict):
     >>> d == bidict(reversed(list(d.items())))
     True
 
+    >>> bidict({"a": 1, "b": 1})  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: Bidirectional dictionary cannot contain repeated values
+
+    >>> del d["e"]  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    KeyError: 'e'
+
     """
 
     _inverse = None
@@ -82,7 +94,7 @@ class bidict(dict):
         self._inverse = {v: k for k, v in self.items()}
         if len(self) != len(self._inverse):
             raise TypeError(
-                "Bidirectional dictionary cannot contain repeated keys or values."
+                "Bidirectional dictionary cannot contain repeated values"
             )
 
     def __setitem__(self, key, value):

--- a/sdcflows/utils/bimap.py
+++ b/sdcflows/utils/bimap.py
@@ -1,0 +1,148 @@
+"""A bidirectional hashmap."""
+import re
+
+_autokey_pat = re.compile(r"^auto_(\d+)$")
+
+
+class bidict(dict):
+    """
+    A bidirectional hashmap.
+
+    >>> d = bidict({"a": 1, "b": 2}, c=3)
+    >>> d["a"]
+    1
+
+    >>> d[1]
+    'a'
+
+    >>> 2 in d
+    True
+
+    >>> "b" in d
+    True
+
+    >>> d["d"] = 4
+    >>> del d["d"]
+    >>> d["d"] = 4
+    >>> del d[4]
+    >>> d
+    {'a': 1, 'b': 2, 'c': 3}
+
+    >>> d["d"] = "d"  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: 'd' <> 'd' is a self-mapping
+
+    >>> d["d"]  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    KeyError: 'd'
+
+    >>> d["b"] = None  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    KeyError: 'b' is already in mapping
+
+    >>> d[1] = None  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    KeyError: '1' is already a value in mapping
+
+    >>> d["d"] = 1  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: '1' is already in mapping
+
+    >>> d["d"] = "a"  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: 'a' is already a key in mapping
+
+    >>> d["unhashable val"] = []  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: value '[]' of unhashable type: 'list'
+
+    >>> d.add("a new value")
+    'auto_00000'
+
+    >>> d["auto_00000"]
+    'a new value'
+
+    >>> d["auto_00001"] = "another value"
+    >>> d.add("a new value")  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: 'a new value' is already in mapping
+
+    >>> d.add("third value")
+    'auto_00002'
+
+    >>> d == bidict(reversed(list(d.items())))
+    True
+
+    """
+
+    _inverse = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._inverse = {v: k for k, v in self.items()}
+        if len(self) != len(self._inverse):
+            raise TypeError(
+                "Bidirectional dictionary cannot contain repeated keys or values."
+            )
+
+    def __setitem__(self, key, value):
+        if key == value:
+            raise TypeError(f"'{key}' <> '{value}' is a self-mapping")
+
+        try:
+            hash(value)
+        except TypeError as exc:
+            raise TypeError(f"value '{value}' of {exc}")
+        try:
+            hash(key)
+        except TypeError as exc:
+            raise TypeError(f"key '{key}' of {exc}")
+
+        if self.__contains__(key):
+            raise KeyError(
+                f"'{key}' is already {'a value' * (key in self._inverse)} in mapping"
+            )
+        if self.__contains__(value):
+            raise ValueError(
+                f"'{value}' is already {'a key' * (value not in self._inverse)} in mapping"
+            )
+
+        super().__setitem__(key, value)
+        self._inverse[value] = key
+
+    def __delitem__(self, key):
+        if not self.__contains__(key):
+            raise KeyError(f"'{key}")
+
+        if super().__contains__(key):
+            del self._inverse[super().__getitem__(key)]
+            super().__delitem__(key)
+        else:
+            super().__delitem__(self._inverse[key])
+            del self._inverse[key]
+
+    def __getitem__(self, key):
+        if key in self._inverse:
+            return self._inverse[key]
+        return super().__getitem__(key)
+
+    def __contains__(self, key):
+        if super().__contains__(key):
+            return True
+        return key in self._inverse
+
+    def add(self, value):
+        """Insert a new value in the bidict, generating an automatic key."""
+        _used = set(
+            int(i.groups()[0])
+            for i in [
+                _autokey_pat.match(k) for k in self.keys() if k.startswith("auto_")
+            ]
+            if i is not None
+        )
+        for i in range(len(_used) + 1):
+            if i not in _used:
+                newkey = f"auto_{i:05d}"
+
+        self.__setitem__(newkey, value)
+        return newkey


### PR DESCRIPTION
This PR implements a bi-directional hash-map (dictionary) instead of a set to track fieldmap estimator IDs.

Instead, the registry can be queried by passing in the fieldmap estimator ID, OR a tuple of path-sources (in which case it returns the ID).

This way, a ``ValueError`` is raised when one tries to establish a fieldmap estimation using the same set of images.

Resolves: #129.