### PR TITLE
ENH: Autogenerate ``B0FieldIdentifiers`` from ``IntendedFor``

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,13 @@ jobs:
             datalad update --merge -d ds001771/
             datalad get -r -d ds001771/ ds001771/sub-36/fmap/*
 
+      - run:
+          name: Install ds000054
+          command: |
+            datalad install -r https://github.com/nipreps-data/ds000054.git
+            datalad update --merge -d ds000054/
+            datalad get -r -d ds000054/ ds000054/sub-100185/fmap/*
+
       - save_cache:
           key: data-v4-{{ .Branch }}-{{ .BuildNum }}
           paths:

--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -89,6 +89,11 @@ jobs:
         datalad install -r https://github.com/nipreps-data/ds001771.git
         datalad update --merge -d ds001771/
         datalad get -r -d ds001771/ ds001771/sub-36/fmap/*
+
+        # ds000054
+        datalad install -r https://github.com/nipreps-data/ds000054.git
+        datalad update --merge -d ds000054/
+        datalad get -r -d ds000054/ ds000054/sub-100185/fmap/*
     - uses: actions/cache@v2
       with:
         path: /var/lib/apt

--- a/sdcflows/conftest.py
+++ b/sdcflows/conftest.py
@@ -15,6 +15,8 @@ layouts = {p.name: BIDSLayout(str(p), validate=False, derivatives=True)
 
 data_dir = Path(__file__).parent / "tests" / "data" / "dsA"
 
+layouts["dsA"] = BIDSLayout(data_dir, validate=False, derivatives=False)
+
 
 def pytest_report_header(config):
     return f"""\

--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -390,7 +390,7 @@ class FieldmapEstimation:
         _estimators[self.bids_id] = self.paths()
 
     def paths(self):
-        """Return a tuple of paths (sorted)."""
+        """Return a tuple of paths that are sorted."""
         return tuple(sorted(str(f.path) for f in self.sources))
 
     def get_workflow(self, **kwargs):

--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -7,10 +7,10 @@ from json import loads
 from bids.layout import BIDSFile, parse_file_entities
 from bids.utils import listify
 from niworkflows.utils.bids import relative_to_root
-from .utils.bimap import bidict
+from .utils.bimap import EstimatorRegistry
 
 
-_estimators = bidict()
+_estimators = EstimatorRegistry()
 
 
 class MetadataError(ValueError):

--- a/sdcflows/tests/data/dsA/sub-01/fmap/sub-01_acq-single_dir-PA_epi.json
+++ b/sdcflows/tests/data/dsA/sub-01/fmap/sub-01_acq-single_dir-PA_epi.json
@@ -1,0 +1,10 @@
+{
+    "PhaseEncodingDirection": "j",
+    "TotalReadoutTime": 0.005,
+    "IntendedFor": [
+        "dwi/sub-01_dir-AP_dwi.nii.gz",
+        "dwi/sub-01_dir-AP_sbref.nii.gz",
+        "func/sub-01_task-rest_bold.nii.gz",
+        "func/sub-01_task-rest_sbref.nii.gz"
+    ]
+}

--- a/sdcflows/tests/test_fieldmaps.py
+++ b/sdcflows/tests/test_fieldmaps.py
@@ -1,6 +1,5 @@
 """test_fieldmaps."""
 import pytest
-from ..utils.bimap import bidict
 from .. import fieldmaps as fm
 
 
@@ -9,7 +8,6 @@ def test_FieldmapFile(testdata_dir):
     fm.FieldmapFile(testdata_dir / "sub-01" / "anat" / "sub-01_T1w.nii.gz")
 
 
-@pytest.fixture(scope="module")
 @pytest.mark.parametrize(
     "inputfiles,method,nsources,raises",
     [
@@ -58,9 +56,7 @@ def test_FieldmapFile(testdata_dir):
         ),
     ],
 )
-def test_FieldmapEstimation(
-    monkeypatch, testdata_dir, inputfiles, method, nsources, raises
-):
+def test_FieldmapEstimation(testdata_dir, inputfiles, method, nsources, raises):
     """Test errors."""
     sub_dir = testdata_dir / "sub-01"
 
@@ -73,7 +69,7 @@ def test_FieldmapEstimation(
             fm.FieldmapEstimation(sources)
 
         # Clean up so this parameter set can be tested.
-        monkeypatch.setattr(fm, "_estimators", bidict())
+        fm._estimators.clear()
 
     fe = fm.FieldmapEstimation(sources)
     assert fe.method == method
@@ -97,11 +93,7 @@ def test_FieldmapEstimation(
 
     # Exercise workflow creation
     wf = fe.get_workflow()
-
-    yield wf == fe.get_workflow()  # Code after this yield will only run on cleanup
-
-    # Clean-up: reset _estimators registry
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    wf == fe.get_workflow()
 
 
 @pytest.mark.parametrize(
@@ -113,22 +105,21 @@ def test_FieldmapEstimation(
         (("anat/sub-01_T1w.nii.gz", "fmap/sub-01_phase2.nii.gz"), TypeError),
     ],
 )
-def test_FieldmapEstimationError(monkeypatch, testdata_dir, inputfiles, errortype):
+def test_FieldmapEstimationError(testdata_dir, inputfiles, errortype):
     """Test errors."""
     sub_dir = testdata_dir / "sub-01"
 
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    fm._estimators.clear()
 
     with pytest.raises(errortype):
         fm.FieldmapEstimation([sub_dir / f for f in inputfiles])
 
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    fm._estimators.clear()
 
 
-def test_FieldmapEstimationIdentifier(monkeypatch, testdata_dir):
+def test_FieldmapEstimationIdentifier(testdata_dir):
     """Check some use cases of B0FieldIdentifier."""
-
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    fm._estimators.clear()
 
     with pytest.raises(ValueError):
         fm.FieldmapEstimation(
@@ -172,7 +163,7 @@ def test_FieldmapEstimationIdentifier(monkeypatch, testdata_dir):
             ]
         )  # Consistent, but already exists
 
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    fm._estimators.clear()
 
     fe = fm.FieldmapEstimation(
         [
@@ -188,4 +179,4 @@ def test_FieldmapEstimationIdentifier(monkeypatch, testdata_dir):
     )
     assert fe.bids_id == "fmap_1"
 
-    monkeypatch.setattr(fm, "_estimators", bidict())
+    fm._estimators.clear()

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -2,6 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Estimate fieldmaps for :abbr:`SDC (susceptibility distortion correction)`."""
 from itertools import product
+from pathlib import Path
 from nipype import logging
 
 LOGGER = logging.getLogger("nipype.workflow")
@@ -31,6 +32,14 @@ def init_fmap_preproc_wf(
 
     Examples
     --------
+    >>> init_fmap_preproc_wf(
+    ...     layout=layouts['ds000054'],
+    ...     omp_nthreads=1,
+    ...     output_dir="/tmp",
+    ...     subject="100185",
+    ... )  # doctest: +ELLIPSIS
+    [FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...')]
+
     >>> init_fmap_preproc_wf(
     ...     layout=layouts['ds001771'],
     ...     omp_nthreads=1,
@@ -71,10 +80,12 @@ def init_fmap_preproc_wf(
     [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='...'),
      FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
      FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
+     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
 
     """
-    from ..fieldmaps import FieldmapEstimation, FieldmapFile
+    from .. import fieldmaps as fm
+    from bids.layout import Query
 
     base_entities = {
         "subject": subject,
@@ -86,7 +97,9 @@ def init_fmap_preproc_wf(
 
     # Set up B0 fieldmap strategies:
     for fmap in layout.get(suffix=["fieldmap", "phasediff", "phase1"], **base_entities):
-        e = FieldmapEstimation(FieldmapFile(fmap.path, metadata=fmap.get_metadata()))
+        e = fm.FieldmapEstimation(
+            fm.FieldmapFile(fmap.path, metadata=fmap.get_metadata())
+        )
         estimators.append(e)
 
     # A bunch of heuristics to select EPI fieldmaps
@@ -101,13 +114,46 @@ def init_fmap_preproc_wf(
         )
         dirs = layout.get_directions(**entities)
         if len(dirs) > 1:
-            e = FieldmapEstimation(
+            e = fm.FieldmapEstimation(
                 [
-                    FieldmapFile(fmap.path, metadata=fmap.get_metadata())
+                    fm.FieldmapFile(fmap.path, metadata=fmap.get_metadata())
                     for fmap in layout.get(direction=dirs, **entities)
                 ]
             )
             estimators.append(e)
+
+    # At this point, only single-PE _epi files WITH ``IntendedFor`` can be automatically processed
+    # (this will be easier with bids-standard/bids-specification#622 in).
+    try:
+        has_intended = layout.get(suffix="epi", IntendedFor=Query.ANY, **base_entities)
+    except ValueError:
+        has_intended = tuple()
+
+    for epi_fmap in has_intended:
+        if epi_fmap.path in fm._estimators.sources:
+            continue  # skip EPI images already considered above
+
+        subject_root = Path(epi_fmap.path.rpartition("/sub-")[0]).parent
+        targets = [epi_fmap] + [
+            layout.get_file(str(subject_root / intent))
+            for intent in epi_fmap.get_metadata()["IntendedFor"]
+        ]
+
+        epi_sources = []
+        for fmap in targets:
+            try:
+                epi_sources.append(
+                    fm.FieldmapFile(fmap.path, metadata=fmap.get_metadata())
+                )
+            except fm.MetadataError:
+                pass
+
+        try:
+            estimators.append(fm.FieldmapEstimation(epi_sources))
+        except (ValueError, TypeError) as exc:
+            LOGGER.warning(
+                f"FieldmapEstimation strategy failed for <{epi_fmap.path}>. Reason: {exc}."
+            )
 
     for e in estimators:
         LOGGER.info(f"{e.method}:: <{':'.join(s.path.name for s in e.sources)}>.")


### PR DESCRIPTION
This PR:

* Improves the bidirectional mapping, wrapped around with a new `EstimatorRegistry` to easily check whether a file has already been included for some estimation method.
* Looks into the `epi` files with ``IntendedFor`` metadata to complete the estimation workflows that can automatically be set up.
* Prepares the codebase for the `B0FieldIdentifier`, should it be accepted by BIDS.

## Improvements to tests
This PR extends the test data available through the pytest fixture with `dsA` (on the repo, empty files) and `ds000054` from *fMRIPrep*. In addition, all testing data has been migrated to a `datalad-osf` solution for easier maintenance and version tracking.