### PR TITLE
ENH: Add a memory check to dynamically limit interpolation blocksize

### DIFF
--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -50,7 +50,6 @@ jobs:
     - name: Install minimal dependencies
       run: |
         $CONDA/bin/pip install -r min-requirements.txt
-        $CONDA/bin/pip install .
         $CONDA/bin/pip install .[tests]
 
     - uses: actions/cache@v2

--- a/sdcflows/utils/misc.py
+++ b/sdcflows/utils/misc.py
@@ -35,3 +35,13 @@ def last(inlist):
     if isinstance(inlist, (list, tuple)):
         return inlist[-1]
     return inlist
+
+
+def get_free_mem():
+    """Probe the free memory right now."""
+    try:
+        from psutil import virtual_memory
+
+        return round(virtual_memory().free, 1)
+    except Exception:
+        return None

--- a/sdcflows/utils/tests/test_misc.py
+++ b/sdcflows/utils/tests/test_misc.py
@@ -1,0 +1,21 @@
+"""Test miscellaneous utilities."""
+import sys
+from collections import namedtuple
+import types
+import pytest
+from ..misc import get_free_mem
+
+
+@pytest.mark.parametrize("retval", [None, 10])
+def test_get_free_mem(monkeypatch, retval):
+    """Test the get_free_mem utility."""
+
+    def mock_func():
+        if retval is None:
+            raise ImportError
+        return namedtuple("Mem", ("free",))(free=retval)
+
+    psutil = types.ModuleType("psutil")
+    psutil.virtual_memory = mock_func
+    monkeypatch.setitem(sys.modules, "psutil", psutil)
+    assert get_free_mem() == retval

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ doc =
     sphinxcontrib-versioning
 docs =
     %(doc)s
+mem =
+    psutil
 tests =
     pytest
     pytest-xdist >= 2.0
@@ -64,6 +66,7 @@ tests =
     coverage
 all =
     %(doc)s
+    %(mem)s
     %(tests)s
 
 [options.package_data]


### PR DESCRIPTION
With very dense coefficients fields, we need to allocate a sparse
array of npixels x ncoefficients x 3-D x 32-bit.
This allocation is short-lived and can be chunked in segments.

This PR dynamically adjusts the chunk size to the actual amount of
free memory.