### PR TITLE
FIX: Make images "plumb" before running ANTs-SyN (and roll-back afterwards)

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -241,9 +241,6 @@ class Coefficients2Warp(SimpleInterface):
         # Calculate the physical coordinates of target grid
         targetnii = nb.load(self.inputs.in_target)
         allmask = np.ones_like(targetnii.dataobj, dtype="uint8")
-        # targetaff = targetnii.affine
-        # voxels = np.argwhere(allmask == 1).astype("float32")
-        # points = apply_affine(targetaff.astype("float32"), voxels)
 
         weights = []
         coeffs = []
@@ -251,9 +248,6 @@ class Coefficients2Warp(SimpleInterface):
         for cname in self.inputs.in_coeff:
             coeff_nii = nb.load(cname)
             wmat = grid_bspline_weights(targetnii, coeff_nii)
-            # wmat = bspline_weights(
-            #     points, coeff_nii, mem_percent=0.1 if self.inputs.low_mem else None,
-            # )
             weights.append(wmat)
             coeffs.append(coeff_nii.get_fdata(dtype="float32").reshape(-1))
 
@@ -284,6 +278,7 @@ class Coefficients2Warp(SimpleInterface):
         field[..., phaseEncDim] = data.reshape(-1)
         aff = targetnii.affine.copy()
         aff[:3, 3] = 0.0
+        # Multiplying by the affine implicitly applies the voxel size to the shift map
         field = nb.affines.apply_affine(aff, field).reshape(fieldshape)
         warpnii = targetnii.__class__(
             field[:, :, :, np.newaxis, :].astype("float32"), targetnii.affine, None


### PR DESCRIPTION
Because ITK handles registration in "physical" coordinates, when the fixed
image's affine is not aligned with the array's axis (i.e., is not plumb or
aligned to the canonical axis) the transform is obtained with alignment to
one axis, but that is not aligned with the data.

To ensure the PE (phase-encoding) direction of the data array and the
corresponding physical axis are aligned, this PR compensates for potential
rotations.

Resolves #12.