### PR TITLE
ENH: Add "*fieldmap-less*" estimations to default heuristics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: |
             datalad install -r https://github.com/nipreps-data/ds001771.git
             datalad update -r --merge -d ds001771/
-            datalad get -r -d ds001771/ ds001771/sub-36/fmap/*
+            datalad get -r -d ds001771/ ds001771/sub-36/*
 
       - run:
           name: Install ds000054

--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -87,12 +87,12 @@ jobs:
         # ds001771
         datalad install -r https://github.com/nipreps-data/ds001771.git
         datalad update --merge -d ds001771/
-        datalad get -r -d ds001771/ ds001771/sub-36/fmap/*
+        datalad get -r -d ds001771/ ds001771/sub-36/*
 
         # ds000054
         datalad install -r https://github.com/nipreps-data/ds000054.git
         datalad update --merge -d ds000054/
-        datalad get -r -d ds000054/ ds000054/sub-100185/fmap/*
+        datalad get -r -d ds000054/ ds000054/sub-100185/*
     - uses: actions/cache@v2
       with:
         path: /var/lib/apt

--- a/sdcflows/tests/data/dsA/dataset_description.json
+++ b/sdcflows/tests/data/dsA/dataset_description.json
@@ -1,0 +1,11 @@
+{
+    "Name": "Test Dataset A, only empty files",
+    "BIDSVersion": "",
+    "License": "CC0",
+    "Authors": ["Esteban O."],
+    "Acknowledgements": "",
+    "HowToAcknowledge": "",
+    "Funding": "",
+    "ReferencesAndLinks": [""],
+    "DatasetDOI": ""
+}

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -2,12 +2,19 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Find fieldmaps on the BIDS inputs for :abbr:`SDC (susceptibility distortion correction)`."""
 from itertools import product
+from contextlib import suppress
 from pathlib import Path
 
 
-def find_estimators(layout, subject=None):
+def find_estimators(layout, subject=None, fmapless=True, force_fmapless=False):
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.
+
+    The "*fieldmap-less*" heuristics only attempt to find ``_dwi`` and ``_bold`` candidates
+    to pair with a ``_T1w`` anatomical reference.
+    For more complicated heuristics (for instance, using ``_T2w`` images or ``_sbref``
+    images,) the :py:class:`~sdcflows.fieldmaps.FieldmapEstimation` object must be
+    created manually by the user.
 
     Parameters
     ----------
@@ -15,6 +22,14 @@ def find_estimators(layout, subject=None):
         An initialized PyBIDS layout.
     subject : :obj:`str`
         Participant label for this single-subject workflow.
+    fmapless : :obj:`bool` or :obj:`set`
+        Indicates if fieldmap-less heuristics should be executed.
+        When ``fmapless`` is a :obj:`set`, it can contain valid BIDS suffices
+        for EPI images (namely, ``"dwi"``, ``"bold"``, or ``"sbref"``).
+        When ``fmapless`` is ``True``, heuristics will use the ``{"bold", "dwi"}`` set.
+    force_fmapless : :obj:`bool`
+        When some other fieldmap estimation methods have been found, fieldmap-less
+        estimation will be skipped except if ``force_fmapless`` is ``True``.
 
     Returns
     -------
@@ -28,43 +43,90 @@ def find_estimators(layout, subject=None):
     >>> find_estimators(
     ...     layout=layouts['ds000054'],
     ...     subject="100185",
+    ...     fmapless=False,
     ... )  # doctest: +ELLIPSIS
-    [FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...')]
+    [FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00000')]
 
     >>> find_estimators(
     ...     layout=layouts['ds001771'],
     ...     subject="36",
     ... )  # doctest: +ELLIPSIS
-    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
+    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='auto_00001'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='auto_00002'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00003'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00004')]
 
     >>> find_estimators(
     ...     layout=layouts['ds001600'],
     ...     subject="1",
     ... )  # doctest: +ELLIPSIS
-    [FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
+    [FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00005'),
+     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00006'),
+     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00007'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00008')]
 
     >>> find_estimators(
     ...     layout=layouts['HCP101006'],
     ...     subject="101006",
     ... )  # doctest: +ELLIPSIS
-    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
+    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00009'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00010')]
 
     >>> find_estimators(
     ...     layout=layouts['dsA'],
     ...     subject="01",
     ... )  # doctest: +ELLIPSIS
-    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>, bids_id='...'),
-     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>, bids_id='...'),
-     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...'),
-     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>, bids_id='...')]
+    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>,
+                        bids_id='auto_00011'),
+     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00012'),
+     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00013'),
+     FieldmapEstimation(sources=<4 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00014'),
+     FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                        bids_id='auto_00015')]
+
+    >>> from .. import fieldmaps as fm
+    >>> fm.clear_registry()
+    >>> find_estimators(
+    ...     layout=layouts['ds000054'],
+    ...     subject="100185",
+    ...     force_fmapless=True,
+    ... )  # doctest: +ELLIPSIS
+    [FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>,
+                        bids_id='auto_00000'),
+     FieldmapEstimation(sources=<3 files>, method=<EstimatorType.ANAT: 5>,
+                        bids_id='auto_00001')]
+
+    >>> find_estimators(
+    ...     layout=layouts['ds001771'],
+    ...     subject="36",
+    ...     force_fmapless=True,
+    ... )  # doctest: +ELLIPSIS
+    [FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>,
+                       bids_id='auto_00002'),
+    FieldmapEstimation(sources=<2 files>, method=<EstimatorType.MAPPED: 4>,
+                       bids_id='auto_00003'),
+    FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                       bids_id='auto_00004'),
+    FieldmapEstimation(sources=<2 files>, method=<EstimatorType.PEPOLAR: 2>,
+                       bids_id='auto_00005'),
+    FieldmapEstimation(sources=<7 files>, method=<EstimatorType.ANAT: 5>,
+                       bids_id='auto_00006'),
+    FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>,
+                       bids_id='auto_00007'),
+    FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>,
+                       bids_id='auto_00008')]
 
     """
     from .. import fieldmaps as fm
@@ -78,6 +140,10 @@ def find_estimators(layout, subject=None):
         "extension": [".nii", ".nii.gz"],
         "space": None,  # Ensure derivatives are not captured
     }
+
+    fmapless = fmapless or {}
+    if fmapless is True:
+        fmapless = {"bold", "dwi"}
 
     estimators = []
 
@@ -138,5 +204,61 @@ def find_estimators(layout, subject=None):
             estimators.append(fm.FieldmapEstimation(epi_sources))
         except (ValueError, TypeError):
             pass
+
+    if estimators and not force_fmapless:
+        fmapless = False
+
+    if not fmapless:
+        return estimators
+
+    # Find fieldmap-less schemes
+    anat_file = layout.get(suffix="T1w", desc=None, **base_entities)
+
+    if not anat_file:
+        return estimators
+
+    from .epimanip import get_trt
+    intended_root = Path(anat_file[0].path).parent.parent
+    for ses, suffix in sorted(product(sessions, fmapless)):
+        candidates = layout.get(suffix=suffix, session=ses, **base_entities)
+
+        # Filter out candidates without defined PE direction
+        epi_targets = []
+        pe_dirs = []
+        ro_totals = []
+
+        for candidate in candidates:
+            meta = candidate.get_metadata()
+            pe_dir = meta.get("PhaseEncodingDirection")
+            if not pe_dir:
+                continue
+
+            pe_dirs.append(pe_dir)
+            ro = 1.0
+            with suppress(ValueError):
+                ro = get_trt(meta, candidate.path)
+            ro_totals.append(ro)
+            meta.update({"TotalReadoutTime": ro})
+            epi_targets.append(
+                fm.FieldmapFile(candidate.path, metadata=meta)
+            )
+
+        for pe_dir in sorted(set(pe_dirs)):
+            pe_ro = [ro for ro, pe in zip(ro_totals, pe_dirs) if pe == pe_dir]
+            for ro_time in sorted(set(pe_ro)):
+                fmfiles, fmpaths = tuple(zip(*[
+                    (target, str(Path(target.path).relative_to(intended_root)))
+                    for i, target in enumerate(epi_targets)
+                    if pe_dirs[i] == pe_dir and ro_totals[i] == ro_time
+                ]))
+                estimators.append(
+                    fm.FieldmapEstimation(
+                        [fm.FieldmapFile(
+                            anat_file[0],
+                            metadata={"IntendedFor": fmpaths}
+                        ), *fmfiles]
+                    )
+                )
+                # import pdb; pdb.set_trace()
 
     return estimators

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -101,6 +101,7 @@ def find_estimators(layout, subject=None, fmapless=True, force_fmapless=False):
     >>> find_estimators(
     ...     layout=layouts['ds000054'],
     ...     subject="100185",
+    ...     fmapless={"bold"},
     ...     force_fmapless=True,
     ... )  # doctest: +ELLIPSIS
     [FieldmapEstimation(sources=<3 files>, method=<EstimatorType.PHASEDIFF: 3>,

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -7,8 +7,6 @@ from ...utils.wrangler import find_estimators
 from ..base import init_fmap_preproc_wf
 
 
-@pytest.mark.skipif(os.getenv("TRAVIS") == "true", reason="this is TravisCI")
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="this is GH Actions")
 @pytest.mark.parametrize(
     "dataset,subject", [("ds000054", "100185"), ("HCP101006", "101006")]
 )
@@ -19,7 +17,7 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
 
     outdir = outdir / "test_base" / dataset
     fm._estimators.clear()
-    estimators = find_estimators(bids_layouts[dataset], subject=subject)
+    estimators = find_estimators(layout=bids_layouts[dataset], subject=subject)
     wf = init_fmap_preproc_wf(
         estimators=estimators,
         omp_nthreads=2,
@@ -42,4 +40,5 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
     if workdir:
         wf.base_dir = str(workdir)
 
-    wf.run(plugin="Linear")
+    if os.getenv("GITHUB_ACTIONS") != "true":
+        wf.run(plugin="Linear")


### PR DESCRIPTION
Implements current *fMRIPrep*'s heuristics for fieldmap-less estimation
with ANTs-SyN.