### PR TITLE
enh: add override to default bspline distance

### DIFF
--- a/sdcflows/workflows/ancillary.py
+++ b/sdcflows/workflows/ancillary.py
@@ -22,6 +22,8 @@ def init_brainextraction_wf(name="brainextraction_wf"):
     ------
     in_file : :obj:`str`
         the GRE magnitude or EPI reference to be brain-extracted
+    bspline_dist : :obj:`int`, optional
+        Integer to replace default distance of b-spline separation for N4
 
     Outputs
     -------
@@ -42,7 +44,14 @@ def init_brainextraction_wf(name="brainextraction_wf"):
 
     wf = Workflow(name=name)
 
-    inputnode = pe.Node(niu.IdentityInterface(fields=("in_file",)), name="inputnode")
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=(
+                "in_file",
+                "bspline_dist"
+            )
+        ),
+        name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=(
@@ -74,6 +83,7 @@ def init_brainextraction_wf(name="brainextraction_wf"):
     # fmt:off
     wf.connect([
         (inputnode, clipper_pre, [("in_file", "in_file")]),
+        (inputnode, n4, [("bspline_dist", "bspline_fitting_distance")]),
         (clipper_pre, n4, [("out_file", "input_image")]),
         (n4, clipper_post, [("output_image", "in_file")]),
         (clipper_post, masker, [("out_file", "in_file")]),


### PR DESCRIPTION
The addition of the EPI brain masking workflow is not quite compatible with rodents as seen here:
![bspline_distance-default](https://user-images.githubusercontent.com/54267723/105871929-b8602d80-5ff1-11eb-8b92-22061f34936b.png)

The proposed PR provides an optional integer to the workflow to override the default b-spline fitting distance. 

This was used to change the b-spline fitting distance to 15, from the default 300:
![bspline_distance-15](https://user-images.githubusercontent.com/54267723/105871925-b72f0080-5ff1-11eb-80b3-4e0012b8b13e.png)

