### PR TITLE
ENH: Add estimation method description to outputs

### DIFF
--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -67,7 +67,7 @@ def init_fmap_preproc_wf(
 
     workflow = Workflow(name=name)
 
-    out_fields = ("fmap", "fmap_ref", "fmap_coeff", "fmap_mask", "fmap_id")
+    out_fields = ("fmap", "fmap_ref", "fmap_coeff", "fmap_mask", "fmap_id", "method")
     out_merge = {
         f: pe.Node(niu.Merge(len(estimators)), name=f"out_merge_{f}")
         for f in out_fields
@@ -144,6 +144,7 @@ def init_fmap_preproc_wf(
                 ("outputnode.fmap_ref", "fmap_ref"),
                 ("outputnode.fmap_coeff", "fmap_coeff"),
                 ("outputnode.fmap_mask", "fmap_mask"),
+                ("outputnode.method", "method")
             ]),
         ])
         # fmt:on

--- a/sdcflows/workflows/fit/fieldmap.py
+++ b/sdcflows/workflows/fit/fieldmap.py
@@ -154,6 +154,8 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     fmap_mask : :obj:`str`
         Path to a binary brain mask corresponding to the ``fmap`` and ``fmap_ref``
         pair.
+    method: :obj:`str`
+        Short description of the estimation method that was run.
 
     """
     from ...interfaces.bspline import (
@@ -166,7 +168,7 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     workflow = Workflow(name=name)
     inputnode = pe.Node(niu.IdentityInterface(fields=INPUT_FIELDS), name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["fmap", "fmap_ref", "fmap_mask", "fmap_coeff"]),
+        niu.IdentityInterface(fields=["fmap", "fmap_ref", "fmap_mask", "fmap_coeff", "method"]),
         name="outputnode",
     )
 
@@ -199,6 +201,7 @@ phase-drift map(s) measure with two consecutive GRE (gradient-recalled echo)
 acquisitions.
 """
         phdiff_wf = init_phdiff_wf(omp_nthreads, debug=debug)
+        outputnode.inputs.method = "FMB (fieldmap-based) - phase-difference map"
 
         # fmt: off
         workflow.connect([
@@ -220,6 +223,7 @@ acquisitions.
 A *B<sub>0</sub>* nonuniformity map (or *fieldmap*) was directly measured with
 an MRI scheme designed with that purpose such as SEI (Spiral-Echo Imaging).
 """
+        outputnode.inputs.method = "FMB (fieldmap-based) - directly measured B0 map"
         # Merge input fieldmap images (assumes all are given in the same units!)
         fmapmrg = pe.Node(
             IntraModalMerge(zero_based_avg=False, hmc=False, to_ras=False),

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -64,6 +64,8 @@ def init_topup_wf(omp_nthreads=1, sloppy=False, debug=False, name="pepolar_estim
         The path of mask corresponding to the ``fmap_ref`` output.
     fmap_coeff : :obj:`str` or :obj:`list` of :obj:`str`
         The path(s) of the B-Spline coefficients supporting the fieldmap.
+    method: :obj:`str`
+        Short description of the estimation method that was run.
 
     """
     from nipype.interfaces.fsl.epi import TOPUP
@@ -91,10 +93,12 @@ def init_topup_wf(omp_nthreads=1, sloppy=False, debug=False, name="pepolar_estim
                 "jacobians",
                 "xfms",
                 "out_warps",
+                "method",
             ]
         ),
         name="outputnode",
     )
+    outputnode.inputs.method = "PEB/PEPOLAR (phase-encoding based / PE-POLARity)"
 
     flatten = pe.Node(Flatten(), name="flatten")
     concat_blips = pe.Node(MergeSeries(), name="concat_blips")

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -135,6 +135,8 @@ def init_syn_sdc_wf(
         The path of an unwarped conversion of files in ``epi_ref``.
     fmap_coeff : :obj:`str` or :obj:`list` of :obj:`str`
         The path(s) of the B-Spline coefficients supporting the fieldmap.
+    method: :obj:`str`
+        Short description of the estimation method that was run.
 
     """
     from pkg_resources import resource_filename as pkgrf
@@ -176,9 +178,10 @@ template [@fieldmapless3].
 """
     inputnode = pe.Node(niu.IdentityInterface(INPUT_FIELDS), name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(["fmap", "fmap_ref", "fmap_coeff", "fmap_mask"]),
+        niu.IdentityInterface(["fmap", "fmap_ref", "fmap_coeff", "fmap_mask", "method"]),
         name="outputnode",
     )
+    outputnode.inputs.method = 'FLB ("fieldmap-less", SyN-based)'
 
     warp_dir = pe.Node(
         niu.Function(function=_warp_dir),


### PR DESCRIPTION
Adds a `method` output field to estimation workflows, to allow easy inspection of type of correction applied.

- Descriptions are ported from the `1.3` series of SDCFlows