### PR TITLE
FIX: Address memory issues of ``Coefficients2Warp``

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -119,7 +119,7 @@ class BSplineApprox(SimpleInterface):
 
         # Calculate spatial location of voxels, and normalize per B-Spline grid
         mask_indices = np.argwhere(mask)
-        fmap_points = apply_affine(fmapnii.affine.astype("float32"), mask_indices)
+        fmap_points = apply_affine(fmapnii.affine, mask_indices).astype("float32")
 
         # Calculate the spatial location of control points
         bs_levels = []
@@ -240,19 +240,27 @@ class Coefficients2Warp(SimpleInterface):
 
         # Calculate the physical coordinates of target grid
         targetnii = nb.load(self.inputs.in_target)
-        allmask = np.ones_like(targetnii.dataobj, dtype="uint8")
+        allmask = np.ones_like(targetnii.dataobj, dtype="bool")
 
         weights = []
         coeffs = []
 
+        # Calculate spatial location of voxels, and normalize per B-Spline grid
+        mask_indices = np.argwhere(allmask)
+        fmap_points = apply_affine(targetnii.affine, mask_indices).astype("float32")
+
+        weights = None
         for cname in self.inputs.in_coeff:
-            coeff_nii = nb.load(cname)
-            wmat = grid_bspline_weights(targetnii, coeff_nii)
-            weights.append(wmat)
-            coeffs.append(coeff_nii.get_fdata(dtype="float32").reshape(-1))
+            level = nb.load(cname)
+            weights = (
+                bspline_weights(fmap_points, level)
+                if weights is None
+                else sparse_vstack((weights, bspline_weights(fmap_points, level)))
+            )
+            coeffs.append(level.get_fdata(dtype="float32").reshape(-1))
 
         data = np.zeros(targetnii.shape, dtype="float32")
-        data[allmask == 1] = np.squeeze(np.vstack(coeffs).T) @ sparse_vstack(weights)
+        data[allmask] = np.squeeze(np.vstack(coeffs).T) @ weights
 
         hdr = targetnii.header.copy()
         hdr.set_data_dtype("float32")
@@ -396,61 +404,6 @@ def bspline_grid(img, control_zooms_mm=DEFAULT_ZOOMS_MM):
     )
 
     return img.__class__(np.zeros(bs_shape, dtype="float32"), bs_affine)
-
-
-def grid_bspline_weights(target_nii, ctrl_nii):
-    """Fast, gridded evaluation."""
-    from scipy.sparse import csr_matrix, vstack
-
-    if isinstance(target_nii, (str, bytes, Path)):
-        target_nii = nb.load(target_nii)
-    if isinstance(ctrl_nii, (str, bytes, Path)):
-        ctrl_nii = nb.load(ctrl_nii)
-
-    shape = target_nii.shape[:3]
-    ctrl_sp = ctrl_nii.header.get_zooms()[:3]
-    ras2ijk = np.linalg.inv(ctrl_nii.affine)
-    origin = apply_affine(ras2ijk, [tuple(target_nii.affine[:3, 3])])[0]
-
-    wd = []
-    for i, (o, n, sp) in enumerate(
-        zip(origin, shape, target_nii.header.get_zooms()[:3])
-    ):
-        locations = np.arange(0, n, dtype="float32") * sp / ctrl_sp[i] + o
-        knots = np.arange(0, ctrl_nii.shape[i], dtype="float32")
-        distance = (locations[np.newaxis, ...] - knots[..., np.newaxis]).astype(
-            "float32"
-        )
-        weights = np.zeros_like(distance, dtype="float32")
-        within_support = np.abs(distance) < 2.0
-        d = np.abs(distance[within_support])
-        weights[within_support] = np.piecewise(
-            d,
-            [d < 1.0, d >= 1.0],
-            [
-                lambda d: (4.0 - 6.0 * d ** 2 + 3.0 * d ** 3) / 6.0,
-                lambda d: (2.0 - d) ** 3 / 6.0,
-            ],
-        )
-        wd.append(weights)
-
-    ctrl_shape = ctrl_nii.shape[:3]
-    data_size = np.prod(shape)
-    wmat = None
-    for i in range(ctrl_shape[0]):
-        sparse_mat = (
-            wd[0][i, np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
-            * wd[1][np.newaxis, :, np.newaxis, np.newaxis, :, np.newaxis]
-            * wd[2][np.newaxis, np.newaxis, :, np.newaxis, np.newaxis, :]
-        ).reshape((-1, data_size))
-        sparse_mat[sparse_mat < 1e-9] = 0
-
-        if wmat is None:
-            wmat = csr_matrix(sparse_mat)
-        else:
-            wmat = vstack((wmat, csr_matrix(sparse_mat)))
-
-    return wmat
 
 
 def bspline_weights(points, ctrl_nii, blocksize=None, mem_percent=None):


### PR DESCRIPTION
This PR ends with the dual implementation of the evaluation of B-Spline weights on the grid of the approximated map. On the one hand, we had a ``grid_bspline_weights`` function, that used vector operations, halfway optimized. On the other, I later wrote ``bspline_weights`` as the former was untenable by the approximation interface.

I vaguely remember having plans to unify them but left the code there untouched.

These changes should ease the memory issues of ``Coefficients2Warp`` (still hooked with the first implementation) - see #194.