### PR TITLE
ENH: Uniformize the grid&affine across EPI "blips" before TOPUP

### DIFF
--- a/sdcflows/interfaces/epi.py
+++ b/sdcflows/interfaces/epi.py
@@ -18,6 +18,7 @@ class _GetReadoutTimeInputSpec(BaseInterfaceInputSpec):
 class _GetReadoutTimeOutputSpec(TraitedSpec):
     readout_time = traits.Float
     pe_direction = traits.Enum("i", "i-", "j", "j-", "k", "k-")
+    pe_dir_fsl = traits.Enum("x", "x-", "y", "y-", "z", "z-")
 
 
 class GetReadoutTime(SimpleInterface):
@@ -34,4 +35,10 @@ class GetReadoutTime(SimpleInterface):
             self.inputs.in_file if isdefined(self.inputs.in_file) else None,
         )
         self._results["pe_direction"] = self.inputs.metadata["PhaseEncodingDirection"]
+        self._results["pe_dir_fsl"] = (
+            self.inputs.metadata["PhaseEncodingDirection"]
+            .replace("i", "x")
+            .replace("j", "y")
+            .replace("k", "z")
+        )
         return runtime

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -176,7 +176,7 @@ def init_topup_wf(
     # fmt:off
     workflow.connect([
         (fix_coeff, unwarp, [("out_coeff", "in_coeff")]),
-        (flatten, unwarp, [("out_data", "in_target")]),
+        (regrid, unwarp, [("out_data", "in_target")]),
         (readout_time, unwarp, [("readout_time", "ro_time"),
                                 ("pe_direction", "pe_dir")]),
         (unwarp, outputnode, [("out_warp", "out_warps"),


### PR DESCRIPTION
Closes #192 

Adds a preprocessing workflow for TOPUP's EPI files.

The workflow:
- Takes in a list of EPI files, each pertaining to one phase-encoding (PE) direction.
- Flattens any 4D EPIs into 3D files, and makes a template "blip".
- Applies N4's INU correction.
- Registers all "blips" to the same space.
- Merges the "blips" into a 4D file to be used by TOPUP.