### PR TITLE
ENH: Double-check conversion from TOPUP to standardized fieldmaps

### DIFF
--- a/sdcflows/interfaces/tests/test_bspline.py
+++ b/sdcflows/interfaces/tests/test_bspline.py
@@ -6,7 +6,7 @@ import pytest
 
 from ..bspline import (
     bspline_grid,
-    Coefficients2Warp,
+    ApplyCoeffsField,
     BSplineApprox,
     TOPUPCoeffReorient,
     _fix_topup_fieldcoeff,
@@ -40,7 +40,7 @@ def test_bsplines(tmp_path, testnum):
 
     os.chdir(tmp_path)
     # Check that we can interpolate the coefficients on a target
-    test1 = Coefficients2Warp(
+    test1 = ApplyCoeffsField(
         in_target=str(tmp_path / "target.nii.gz"),
         in_coeff=str(tmp_path / "coeffs.nii.gz"),
         pe_dir="j-",
@@ -91,8 +91,8 @@ def test_topup_coeffs(tmpdir, testdata_dir):
 def test_topup_coeffs_interpolation(tmpdir, testdata_dir):
     """Check that our interpolation is not far away from TOPUP's."""
     tmpdir.chdir()
-    result = Coefficients2Warp(
-        in_target=str(testdata_dir / "epi.nii.gz"),
+    result = ApplyCoeffsField(
+        in_target=[str(testdata_dir / "epi.nii.gz")] * 2,
         in_coeff=str(testdata_dir / "topup-coeff-fixed.nii.gz"),
         pe_dir="j-",
         ro_time=1.0,

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -118,7 +118,7 @@ class B0FieldTransform:
         voxcoords[pe_axis, ...] += vsm * ro_time
 
         # Prepare data
-        data = np.asanyarray(spatialimage.dataobj)
+        data = np.squeeze(np.asanyarray(spatialimage.dataobj))
         output_dtype = output_dtype or data.dtype
 
         # Resample

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -23,7 +23,9 @@ A *B<sub>0</sub>*-nonuniformity map (or *fieldmap*) was estimated based on two (
 echo-planar imaging (EPI) references """
 
 
-def init_topup_wf(omp_nthreads=1, sloppy=False, debug=False, name="pepolar_estimate_wf"):
+def init_topup_wf(
+    omp_nthreads=1, sloppy=False, debug=False, name="pepolar_estimate_wf"
+):
     """
     Create the PEPOLAR field estimation workflow based on FSL's ``topup``.
 

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -178,6 +178,8 @@ def init_topup_wf(omp_nthreads=1, sloppy=False, debug=False, name="pepolar_estim
     )
 
     def _getpe(in_meta):
+        if isinstance(in_meta, list):
+            return [m["PhaseEncodingDirection"] for m in in_meta]
         return in_meta["PhaseEncodingDirection"]
 
     # fmt:off


### PR DESCRIPTION
This PR extends the TOPUP workflow with a few nodes to apply the correction outside TOPUP/ApplyTOPUP.

This extension allows the developer double-check that the conversion from TOPUP outpus is done correctly, and the correction looks good.

Depends: #203.