### PR TITLE
ENH: Add slice padding to TOPUP

### DIFF
--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -267,6 +267,26 @@ class DenoiseImage(_DenoiseImageBase, _CopyHeaderInterface):
     _copy_header_map = {"output_image": "input_image"}
 
 
+class PadSlicesInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="3D or 4D NIfTI image")
+
+
+class PadSlicesOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc="The output file with even number of slices")
+    padded = traits.Bool(desc="Indicator if the input image was padded")
+
+
+class PadSlices(SimpleInterface):
+    input_spec = PadSlicesInputSpec
+    output_spec = PadSlicesOutputSpec
+
+    def _run_interface(self, runtime):
+        self._results["out_file"], self._results["padded"] = _pad_num_slices(
+            self.inputs.in_file, runtime.cwd,
+        )
+        return runtime
+
+
 def _flatten(inlist, max_trs=50, out_dir=None):
     """
     Split the input EPIs and generate a flattened list with corresponding metadata.
@@ -384,3 +404,40 @@ def _reoblique(in_epi, in_plumb, in_field, in_mask=None, newpath=None):
         masknii.__class__(masknii.dataobj, epinii.affine, hdr).to_filename(out_files[2])
 
     return out_files
+
+
+def _pad_num_slices(in_file, newpath=None):
+    """
+    Check if image has an even number of slices.
+    If it does, return the image unaltered.
+    Otherwise, return the image with an empty slice added.
+
+    Parameters
+    ----------
+    img : :obj:`str` or :py:class:`~nibabel.spatialimages.SpatialImage`
+        3D or 4D NIfTI image
+
+    Returns
+    -------
+    file : :obj:`str`
+        The output file with even number of slices
+    padded : :obj:`bool`
+        Indicator if the input image was padded.
+
+    """
+    import nibabel as nb
+    from nipype.utils.filemanip import fname_presuffix
+    import numpy as np
+
+    img = nb.load(in_file)
+    if img.shape[2] % 2 == 0:
+        return in_file, False
+
+    pwidth = [(0,0)] * len(img.shape)
+    pwidth[2] = (0, 1)
+    padded = np.pad(img.dataobj, pwidth)
+    hdr = img.header
+    hdr.set_data_shape(padded.shape)
+    out_file = fname_presuffix(in_file, suffix="_padded", newpath=newpath)
+    img.__class__(padded, img.affine, header=hdr).to_filename(out_file)
+    return out_file, True

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -138,7 +138,8 @@ def init_topup_wf(
         iterfield=["metadata", "in_file"],
         run_without_submitting=True,
     )
-    pad_slices = pe.Node(PadSlices(), name="pad_slices")
+    pad_blip_slices = pe.Node(PadSlices(), name="pad_blip_slices")
+    pad_ref_slices = pe.Node(PadSlices(), name="pad_ref_slices")
 
     topup = pe.Node(
         TOPUP(
@@ -164,7 +165,8 @@ def init_topup_wf(
         (regrid, concat_blips, [("out_data", "in_files")]),
         (readout_time, topup, [("readout_time", "readout_times"),
                                ("pe_dir_fsl", "encoding_direction")]),
-        (regrid, fix_coeff, [("reference", "fmap_ref")]),
+        (regrid, pad_ref_slices, [("reference", "in_file")]),
+        (pad_ref_slices, fix_coeff, [("out_file", "fmap_ref")]),
         (readout_time, fix_coeff, [(("pe_direction", _front), "pe_dir")]),
         (topup, fix_coeff, [("out_fieldcoef", "in_coeff")]),
         (topup, outputnode, [("out_jacs", "jacobians"),
@@ -181,8 +183,8 @@ def init_topup_wf(
     if not debug:
         # fmt: off
         workflow.connect([
-            (concat_blips, pad_slices, [("out_file", "in_file")]),
-            (pad_slices, topup, [("out_file", "in_file")]),
+            (concat_blips, pad_blip_slices, [("out_file", "in_file")]),
+            (pad_blip_slices, topup, [("out_file", "in_file")]),
             (topup, ref_average, [("out_corrected", "in_file")]),
             (topup, outputnode, [("out_field", "fmap"),
                                  ("out_warps", "out_warps")]),
@@ -206,8 +208,8 @@ def init_topup_wf(
     # fmt:off
     workflow.connect([
         (concat_blips, realign, [("out_file", "in_file")]),
-        (realign, pad_slices, [("out_file", "in_file")]),
-        (pad_slices, topup, [("out_file", "in_file")]),
+        (realign, pad_blip_slices, [("out_file", "in_file")]),
+        (pad_blip_slices, topup, [("out_file", "in_file")]),
         (fix_coeff, unwarp, [("out_coeff", "in_coeff")]),
         (realign, split_blips, [("out_file", "in_file")]),
         (split_blips, unwarp, [("out_files", "in_target")]),


### PR DESCRIPTION
Because of the configuration we're using, TOPUP fails when given an image with an odd number of slices. This adds a new interface `PadSlice` that adds an additional empty slice to images with odd numbered slices.

~~Once I test this, I'll convert out of draft mode.~~

A few questions:
- Does the pad interface need to take into account image orientation?
- Do we want to remove the added slice after calculating TOPUP correction?