### PR TITLE
MNT: Use keys.openpgp.org over sks-keyservers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,15 @@ jobs:
             - data-v4-{{ .Branch }}-
             - data-v4-master-
             - data-v4-
-
+      - checkout:
+          path: /tmp/src/sdcflows
       - run:
           name: Setup git-annex
           command: |
             if [[ ! -d /usr/lib/git-annex.linux ]]; then
               wget -O- http://neuro.debian.net/lists/focal.us-ca.full | tee /etc/apt/sources.list.d/neurodebian.sources.list
-              apt-key adv --recv-keys --keyserver hkps://keys.openpgp.org 0xA5D32F012649A5A9
+              apt-key add /tmp/src/sdcflows/.docker/files/neurodebian.gpg
+              apt-key adv --recv-keys --keyserver hkps://keys.openpgp.org 0xA5D32F012649A5A9 || true
               apt update && apt-get install -y --no-install-recommends git-annex-standalone
             fi
             git config --global user.name 'NiPreps Bot'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             if [[ ! -d /usr/lib/git-annex.linux ]]; then
               wget -O- http://neuro.debian.net/lists/focal.us-ca.full | tee /etc/apt/sources.list.d/neurodebian.sources.list
-              apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
+              apt-key adv --recv-keys --keyserver hkps://keys.openpgp.org 0xA5D32F012649A5A9
               apt update && apt-get install -y --no-install-recommends git-annex-standalone
             fi
             git config --global user.name 'NiPreps Bot'

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 # Installing Neurodebian packages (FSL, AFNI, git)
 RUN curl -sSL "http://neuro.debian.net/lists/$( lsb_release -c | cut -f2 ).us-ca.full" >> /etc/apt/sources.list.d/neurodebian.sources.list && \
     apt-key add /usr/local/etc/neurodebian.gpg && \
-    (apt-key adv --refresh-keys --keyserver hkp://ha.pool.sks-keyservers.net 0xA5D32F012649A5A9 || true) && \
+    (apt-key adv --refresh-keys --keyserver hkps://keys.openpgp.org 0xA5D32F012649A5A9 || true) && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
                     fsl-core=5.0.9-5~nd16.04+1 \


### PR DESCRIPTION
Closes #220 for master. Need to backport correctly (see #222).