### PR TITLE
FIX: Bump machine convenience images, ensure latest pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
 
   build_n_pytest:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202107-02
     working_directory: /tmp/tests
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -411,7 +411,7 @@ jobs:
 
   deploy_docker:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202107-02
     working_directory: /tmp/src/
     steps:
       - restore_cache:
@@ -468,7 +468,8 @@ jobs:
           command: |
             python3 -m venv /tmp/install_sdist
             source /tmp/install_sdist/bin/activate
-            python3 -m pip install "setuptools ~= 45.0" "pip>=10.0.1"
+            python3 -m pip install -U pip
+            python3 -m pip install "setuptools ~= 45.0"
             THISVERSION=$( python3 setup.py --version )
             THISVERSION=${CIRCLE_TAG:-$THISVERSION}
             python3 -m pip install dist/sdcflows*.tar.gz


### PR DESCRIPTION
A quick fix for the `setuptools_scm` error we are now encountering - just update pip.