### PR TITLE
CI: Update node and gh-pages, push docs without history

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 docs_deploy: &docs
   docker:
-    - image: node:8.10.0
+    - image: node:16.8.0
   working_directory: /tmp/gh-pages
   steps:
     - run:
@@ -16,7 +16,7 @@ docs_deploy: &docs
     - run:
         name: Install gh-pages tool
         command: |
-          npm install -g --silent gh-pages@2.0.1
+          npm install -g --silent gh-pages@3.2.3
     - checkout
     - run:
         name: Set git settings
@@ -30,7 +30,7 @@ docs_deploy: &docs
         command: touch docs/_build/html/.nojekyll
     - run:
         name: Deploy docs to gh-pages branch
-        command: gh-pages --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
+        command: gh-pages --no-history --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
 
 version: 2
 jobs:


### PR DESCRIPTION
Following https://github.com/nipreps/niworkflows/pull/622. gh-pages 3 dropped support for node<10, so I just went ahead and updated to latest.

Closes #221.