### PR TITLE
ENH: Improve support of 4D in ``sdcflows.interfaces.bspline.ApplyCoeffsField``

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -212,7 +212,7 @@ class BSplineApprox(SimpleInterface):
 
 
 class _ApplyCoeffsFieldInputSpec(BaseInterfaceInputSpec):
-    in_target = InputMultiObject(
+    in_data = InputMultiObject(
         File(exist=True, mandatory=True, desc="input EPI data to be corrected")
     )
     in_coeff = InputMultiObject(
@@ -235,7 +235,7 @@ class _ApplyCoeffsFieldInputSpec(BaseInterfaceInputSpec):
             "k",
             "k-",
             mandatory=True,
-            desc="the phase-encoding direction corresponding to in_target",
+            desc="the phase-encoding direction corresponding to in_data",
         )
     )
 
@@ -279,18 +279,18 @@ class ApplyCoeffsField(SimpleInterface):
             unwarp = B0FieldTransform(
                 coeffs=[nb.load(cname) for cname in self.inputs.in_coeff]
             )
-            unwarp.fit(self.inputs.in_target[0])
+            unwarp.fit(self.inputs.in_data[0])
 
             # Displacements field is constant through time
             self._results["out_field"] = filename(
-                self.inputs.in_target[0], suffix="_field"
+                self.inputs.in_data[0], suffix="_field"
             )
             unwarp.shifts.to_filename(self._results["out_field"])
 
         ro_time = defaultlist(self.inputs.ro_time)
         pe_dir = defaultlist(self.inputs.pe_dir)
 
-        for i, fname in enumerate(self.inputs.in_target):
+        for i, fname in enumerate(self.inputs.in_data):
             pe = pe_dir[i]
             ro = ro_time[i]
 

--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -41,6 +41,8 @@ from nipype.interfaces.base import (
 )
 
 from sdcflows.transform import grid_bspline_weights as gbsw, B0FieldTransform
+from sdcflows.utils.misc import defaultlist
+
 
 LOW_MEM_BLOCK_SIZE = 1000
 DEFAULT_ZOOMS_MM = (40.0, 40.0, 20.0)  # For human adults (mid-frequency), in mm
@@ -262,9 +264,6 @@ class ApplyCoeffsField(SimpleInterface):
         self._results["out_warp"] = []
         self._results["out_corrected"] = []
 
-        # Retrieve the number of target 3D EPIs
-        n_inputs = len(self.inputs.in_target)
-
         # Load head-motion correction matrices
         hmc_mats = None
         unwarp = None
@@ -288,13 +287,8 @@ class ApplyCoeffsField(SimpleInterface):
             )
             unwarp.shifts.to_filename(self._results["out_field"])
 
-        ro_time = self.inputs.ro_time
-        if len(ro_time) == 1:
-            ro_time = [ro_time[0]] * n_inputs
-
-        pe_dir = self.inputs.pe_dir
-        if len(pe_dir) == 1:
-            pe_dir = [pe_dir[0]] * n_inputs
+        ro_time = defaultlist(self.inputs.ro_time)
+        pe_dir = defaultlist(self.inputs.pe_dir)
 
         for i, fname in enumerate(self.inputs.in_target):
             pe = pe_dir[i]

--- a/sdcflows/interfaces/tests/test_bspline.py
+++ b/sdcflows/interfaces/tests/test_bspline.py
@@ -63,7 +63,7 @@ def test_bsplines(tmp_path, testnum):
     os.chdir(tmp_path)
     # Check that we can interpolate the coefficients on a target
     test1 = ApplyCoeffsField(
-        in_target=str(tmp_path / "target.nii.gz"),
+        in_data=str(tmp_path / "target.nii.gz"),
         in_coeff=str(tmp_path / "coeffs.nii.gz"),
         pe_dir="j-",
         ro_time=1.0,
@@ -114,7 +114,7 @@ def test_topup_coeffs_interpolation(tmpdir, testdata_dir):
     """Check that our interpolation is not far away from TOPUP's."""
     tmpdir.chdir()
     result = ApplyCoeffsField(
-        in_target=[str(testdata_dir / "epi.nii.gz")] * 2,
+        in_data=[str(testdata_dir / "epi.nii.gz")] * 2,
         in_coeff=str(testdata_dir / "topup-coeff-fixed.nii.gz"),
         pe_dir="j-",
         ro_time=1.0,

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -54,6 +54,12 @@ class B0FieldTransform:
         Implements Eq. :math:`\eqref{eq:1}`, interpolating :math:`f(\mathbf{s})`
         for all voxels in the target-image's extent.
 
+        Returns
+        -------
+        updated : :obj:`bool`
+            ``True`` if the internal field representation was fit,
+            ``False`` if cache was valid and will be reused.
+
         """
         # Calculate the physical coordinates of target grid
         if isinstance(spatialimage, (str, bytes, Path)):
@@ -66,7 +72,7 @@ class B0FieldTransform:
             if np.all(newshape == self.shifts.shape) and np.allclose(
                 newaff, self.shifts.affine
             ):
-                return
+                return False
 
         weights = []
         coeffs = []
@@ -89,6 +95,7 @@ class B0FieldTransform:
 
         # Cache
         self.shifts = nb.Nifti1Image(vsm, spatialimage.affine, None)
+        return True
 
     def apply(
         self,
@@ -153,8 +160,7 @@ class B0FieldTransform:
         if self.xfm is None:
             ijk_axis = tuple([np.arange(s) for s in vsm.shape])
             voxcoords = np.array(
-                np.meshgrid(*ijk_axis, indexing="ij"),
-                dtype="float32"
+                np.meshgrid(*ijk_axis, indexing="ij"), dtype="float32"
             ).reshape(3, -1)
         else:
             # Map coordinates from reference to time-step

--- a/sdcflows/utils/misc.py
+++ b/sdcflows/utils/misc.py
@@ -67,35 +67,3 @@ def get_free_mem():
         return round(virtual_memory().free, 1)
     except Exception:
         return None
-
-
-class defaultlist(list):
-    """
-    A sort of default dict for lists.
-
-    Examples
-    --------
-    >>> defaultlist(range(3))
-    [0, 1, 2]
-
-    >>> defaultlist(["abc"])[100]
-    'abc'
-
-    >>> defaultlist(range(3))[1]
-    1
-
-    >>> l = defaultlist(reversed(range(3)))
-    >>> l[0]
-    2
-
-    >>> _ = l.pop(0)
-    >>> _ = l.pop(0)
-    >>> l[4]
-    0
-
-    """
-
-    def __getitem__(self, i):
-        if len(self) == 1:
-            i = 0
-        return super().__getitem__(i)

--- a/sdcflows/utils/misc.py
+++ b/sdcflows/utils/misc.py
@@ -67,3 +67,35 @@ def get_free_mem():
         return round(virtual_memory().free, 1)
     except Exception:
         return None
+
+
+class defaultlist(list):
+    """
+    A sort of default dict for lists.
+
+    Examples
+    --------
+    >>> defaultlist(range(3))
+    [0, 1, 2]
+
+    >>> defaultlist(["abc"])[100]
+    'abc'
+
+    >>> defaultlist(range(3))[1]
+    1
+
+    >>> l = defaultlist(reversed(range(3)))
+    >>> l[0]
+    2
+
+    >>> _ = l.pop(0)
+    >>> _ = l.pop(0)
+    >>> l[4]
+    0
+
+    """
+
+    def __getitem__(self, i):
+        if len(self) == 1:
+            i = 0
+        return super().__getitem__(i)

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -107,7 +107,7 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
     workflow.connect([
         (inputnode, rotime, [(("distorted", _pop), "in_file"),
                              ("metadata", "metadata")]),
-        (inputnode, resample, [("distorted", "in_target"),
+        (inputnode, resample, [("distorted", "in_data"),
                                ("fmap_coeff", "in_coeff"),
                                ("hmc_xforms", "in_xfms")]),
         (rotime, resample, [("readout_time", "ro_time"),

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -76,7 +76,7 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
     """
     from sdcflows.interfaces.epi import GetReadoutTime
     from sdcflows.interfaces.bspline import ApplyCoeffsField
-    from sdcflows.ancillary import init_brainextraction_wf
+    from sdcflows.workflows.ancillary import init_brainextraction_wf
     from sdcflows.utils.misc import front as _pop
 
     workflow = Workflow(name=name)

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -74,9 +74,10 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
         a fast mask calculated from the corrected EPI reference.
 
     """
-    from ...interfaces.epi import GetReadoutTime
-    from ...interfaces.bspline import ApplyCoeffsField
-    from ..ancillary import init_brainextraction_wf
+    from sdcflows.interfaces.epi import GetReadoutTime
+    from sdcflows.interfaces.bspline import ApplyCoeffsField
+    from sdcflows.ancillary import init_brainextraction_wf
+    from sdcflows.utils.misc import front as _pop
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
@@ -100,7 +101,7 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
 
     # fmt:off
     workflow.connect([
-        (inputnode, rotime, [("distorted", "in_file"),
+        (inputnode, rotime, [(("distorted", _pop), "in_file"),
                              ("metadata", "metadata")]),
         (inputnode, resample, [("distorted", "in_target"),
                                ("fmap_coeff", "in_coeff"),

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -90,14 +90,20 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["fieldmap", "fieldwarp", "corrected", "corrected_ref", "corrected_mask"]
+            fields=[
+                "fieldmap",
+                "fieldwarp",
+                "corrected",
+                "corrected_ref",
+                "corrected_mask",
+            ]
         ),
         name="outputnode",
     )
 
     rotime = pe.Node(GetReadoutTime(), name="rotime")
     rotime.interface._always_run = debug
-    resample = pe.Node(ApplyCoeffsField(), name="resample")
+    resample = pe.Node(ApplyCoeffsField(num_threads=omp_nthreads), name="resample")
     merge = pe.Node(MergeSeries(), name="merge")
     average = pe.Node(RobustAverage(mc_method=None), name="average")
 

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -55,6 +55,8 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
         dictionary of metadata corresponding to the target EPI image
     fmap_coeff
         fieldmap coefficients in distorted EPI space.
+    hmc_xforms
+        list of head-motion correction matrices (in ITK format)
 
     Outputs
     -------
@@ -78,7 +80,9 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["distorted", "metadata", "fmap_coeff"]),
+        niu.IdentityInterface(
+            fields=["distorted", "metadata", "fmap_coeff", "hmc_xforms"]
+        ),
         name="inputnode",
     )
     outputnode = pe.Node(
@@ -99,7 +103,8 @@ def init_unwarp_wf(omp_nthreads=1, debug=False, name="unwarp_wf"):
         (inputnode, rotime, [("distorted", "in_file"),
                              ("metadata", "metadata")]),
         (inputnode, resample, [("distorted", "in_target"),
-                               ("fmap_coeff", "in_coeff")]),
+                               ("fmap_coeff", "in_coeff"),
+                               ("hmc_xforms", "in_xfms")]),
         (rotime, resample, [("readout_time", "ro_time"),
                             ("pe_direction", "pe_dir")]),
         (resample, outputnode, [("out_field", "fieldmap"),

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -212,7 +212,7 @@ def init_topup_wf(
         (pad_blip_slices, topup, [("out_file", "in_file")]),
         (fix_coeff, unwarp, [("out_coeff", "in_coeff")]),
         (realign, split_blips, [("out_file", "in_file")]),
-        (split_blips, unwarp, [("out_files", "in_target")]),
+        (split_blips, unwarp, [("out_files", "in_data")]),
         (readout_time, unwarp, [("readout_time", "ro_time"),
                                 ("pe_direction", "pe_dir")]),
         (unwarp, outputnode, [("out_warp", "out_warps"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires =
     setuptools_scm_git_archive
     toml
 install_requires =
+    attrs >= 20.1.0
     nibabel >=3.0.1
     nipype >=1.5.1,<2.0
     niworkflows >= 1.4.0rc5


### PR DESCRIPTION
This PR revises the implementation of the core unwarping interface, by enabling `sdcflows.transforms.B0FieldTransform` to project the coefficients representing the fieldmap into each volume of the input through the head-motion correction matrix, thereby moving the fieldmap with the head motion of that frame and hence applying time-step-wise correction.

I'm not confident this will really add substantial accuracy, but theoretically is the way to go. Given the sophistication (and the pervasive interpolation for each frame of the bspline field), this is not implemented elsewhere (except, perhaps, for applyTOPUP).

Resolves: #233.
Initiated-by: nipreps/fmriprep#2210.
