### PR TITLE
ENH: Add max_trs parameter to PEPOLAR workflows, set default to 5

### DIFF
--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -51,7 +51,7 @@ class _FlattenInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="list of metadata",
     )
-    max_trs = traits.Int(50, usedefault=True, desc="only pick first TRs")
+    max_trs = traits.Int(5, usedefault=True, desc="only pick first TRs")
 
 
 class _FlattenOutputSpec(TraitedSpec):

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -104,6 +104,8 @@ def init_topup_wf(
 """
 
     inputnode = pe.Node(niu.IdentityInterface(fields=INPUT_FIELDS), name="inputnode")
+    # Set default so not overridden by `Undefined`. Can be overridden by connection.
+    inputnode.inputs.max_trs = 5
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -278,6 +280,9 @@ with `3dQwarp` (@afni; AFNI {''.join(['%02d' % v for v in afni.Info().version() 
 """
 
     inputnode = pe.Node(niu.IdentityInterface(fields=INPUT_FIELDS), name="inputnode")
+    # Old fMRIPrep default behavior; unused as of 21.0.0 and free to be changed
+    # to something sensible.
+    inputnode.inputs.max_trs = 50
 
     outputnode = pe.Node(
         niu.IdentityInterface(fields=["fmap", "fmap_ref"]), name="outputnode"


### PR DESCRIPTION
From https://github.com/nipreps/sdcflows/pull/258#issuecomment-1013108359.

TOPUP will gladly use as many volumes as we give it, and does not simply find an average volume in each direction. So 50 volumes is quite a lot. In no cases do people acquiring PEPOLAR fieldmaps actually acquire 50 volumes. The most observed in OpenNeuro is 20, and 85% of datasets use 5 or fewer.

By setting the default to 5, we match the likely intent of a majority of observed cases. By adding it as a parameter, we allow downstream tools like fMRIPrep and dMRIPrep to choose (or provide a CLI parameter for users to choose) a more appropriate number.

Changing the default value may violate our bug-fix rules, so that might need to go in a new minor series. But adding the `max_trs` input could work in bug-fix, as leaving it undefined should leave behavior unchanged. That would allow fMRIPrep 21.0 to give users the ability to use BOLD files without requiring useless hours of processing.