### PR TITLE
REL: 2.0.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.0.11 (January 21, 2022)
+==========================
+Patch release in the 2.0.x series.
+
+* FIX: Create one fieldmap estimator per EPI-IntendedFor pair (#258)
+* DOCKER: Build with FSL 6 (#254)
+
 2.0.10 (December 13, 2021)
 ==========================
 Patch release in the 2.0.x series.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.0.11 (January 21, 2022)
+2.0.11 (January 22, 2022)
 ==========================
 Patch release in the 2.0.x series.
 

--- a/sdcflows/__init__.py
+++ b/sdcflows/__init__.py
@@ -1,6 +1,6 @@
 """SDCflows - :abbr:`SDC (susceptibility distortion correction)` by DUMMIES, for dummies."""
 __packagename__ = "sdcflows"
-__copyright__ = "2020, The NiPreps developers"
+__copyright__ = "2022, The NiPreps developers"
 try:
     from ._version import __version__
 except ModuleNotFoundError:


### PR DESCRIPTION
In preparation for an fMRIPrep 21.0.1 release.

After this, I will also be creating a `maint/2.0.x` branch so we can start including non-bugfix improvements into `master`.