### PR TITLE
MAINT: Allow compatibility with new niworkflows minor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     attrs >= 20.1.0
     nibabel >=3.0.1
     nipype >=1.5.1,<2.0
-    niworkflows ~= 1.4.2 
+    niworkflows >= 1.4.2, < 1.6
     nitransforms ~= 21.0.0
     numpy
     pybids >= 0.12.1


### PR DESCRIPTION
`niworkflows` 1.5.0 is out, but no breaking changes have been added.