### PR TITLE
MAINT: Loosen installation restrictions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -86,15 +86,16 @@ jobs:
         path: |
           /usr/share/miniconda/pkgs
           /home/runner/.cache/pip
-        key: python-${{ matrix.python-version }}-v2
+        key: python-${{ matrix.python-version }}-v3
         restore-keys: |
-          python-${{ matrix.python-version }}-
+          python-${{ matrix.python-version }}-v3
     - name: Install DataLad
       run: |
         $CONDA/bin/conda install -c conda-forge git-annex datalad pip
         $CONDA/bin/pip install datalad-osf
     - uses: actions/checkout@v2
     - name: Install minimal dependencies
+      timeout-minutes: 5
       run: |
         $CONDA/bin/pip install -r min-requirements.txt
         $CONDA/bin/pip install .[tests]

--- a/min-requirements.txt
+++ b/min-requirements.txt
@@ -7,5 +7,5 @@ nitransforms==21.0.0
 numpy
 pybids==0.12.1
 scikit-image==0.18
-scipy==1.6
+scipy==1.6.0
 templateflow==0.6

--- a/min-requirements.txt
+++ b/min-requirements.txt
@@ -4,7 +4,7 @@ nibabel==3.0.1
 nipype==1.5.1
 niworkflows==1.4.2
 nitransforms==21.0.0
-numpy
+numpy==1.21.0
 pybids==0.12.1
 scikit-image==0.18
 scipy==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ nibabel>=3.0.1
 nipype<2.0,>=1.5.1
 niworkflows<1.6,>=1.4.2
 nitransforms>=21.0.0
-numpy
+numpy>=1.21.0
 pybids>=0.12.1
 scikit-image>=0.18
 scipy>=1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 attrs>=20.1.0
 nibabel>=3.0.1
 nipype<2.0,>=1.5.1
-niworkflows~=1.4.2
-nitransforms~=21.0.0
+niworkflows<1.6,>=1.4.2
+nitransforms>=21.0.0
 numpy
 pybids>=0.12.1
 scikit-image>=0.18
-scipy~=1.6
+scipy>=1.6.0
 templateflow>=0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,11 @@ install_requires =
     nibabel >=3.0.1
     nipype >=1.5.1,<2.0
     niworkflows >= 1.4.2, < 1.6
-    nitransforms ~= 21.0.0
+    nitransforms >= 21.0.0
     numpy
     pybids >= 0.12.1
     scikit-image >= 0.18
-    scipy ~= 1.6
+    scipy >= 1.6.0
     templateflow >= 0.6
 packages = find:
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     nipype >=1.5.1,<2.0
     niworkflows >= 1.4.2, < 1.6
     nitransforms >= 21.0.0
-    numpy
+    numpy >= 1.21.0
     pybids >= 0.12.1
     scikit-image >= 0.18
     scipy >= 1.6.0


### PR DESCRIPTION
Since sdcflows is nipreps middleware and will be used by various tools, we should not be overtly strict on installations.