### PR TITLE
MAINT: Unavilable data from OSF remote (datalad) for CircleCI tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Install Brain extraction tests
           command: |
-            datalad install -r https://github.com/nipreps-data/brain-extraction-tests.git
+            datalad install -r https://gin.g-node.org/nipreps-data/brain-extraction-tests.git
             datalad update --merge -d brain-extraction-tests/
             datalad get -r -J 2 -d brain-extraction-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Install Brain extraction tests
           command: |
-            datalad install -r https://gin.g-node.org/nipreps-data/brain-extraction-tests.git
+            datalad install -r https://gin.g-node.org/nipreps-data/brain-extraction-tests
             datalad update --merge -d brain-extraction-tests/
             datalad get -r -J 2 -d brain-extraction-tests
 


### PR DESCRIPTION
The OSF repository still exists and is public, so some little change in the internals of datalad might have provoked this issue.

While we discover the culprit, I have pushed the data to GIN

Resolves: #275.