### PR TITLE
ENH: Calculate robust average of EPI inputs to TOPUP workflow

### DIFF
--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -118,6 +118,7 @@ def init_topup_wf(
     )
     outputnode.inputs.method = "PEB/PEPOLAR (phase-encoding based / PE-POLARity)"
 
+    epis_avg = pe.MapNode(RobustAverage(), name="epis_avg", iterfield="in_file")
     flatten = pe.Node(Flatten(), name="flatten")
     regrid = pe.Node(UniformGrid(reference=grid_reference), name="regrid")
     concat_blips = pe.Node(MergeSeries(affine_tolerance=1e-4), name="concat_blips")
@@ -146,8 +147,9 @@ def init_topup_wf(
 
     # fmt: off
     workflow.connect([
-        (inputnode, flatten, [("in_data", "in_data"),
-                              ("metadata", "in_meta")]),
+        (inputnode, epis_avg, [("in_data", "in_file")]),
+        (inputnode, flatten, [("metadata", "in_meta")]),
+        (epis_avg, flatten, [("out_file", "in_data")]),
         (flatten, readout_time, [("out_data", "in_file"),
                                  ("out_meta", "metadata")]),
         (flatten, regrid, [("out_data", "in_data")]),


### PR DESCRIPTION
This PR uses BIDS' interpretation of a run, and disables the nested flattening of inputs to topup. Instead 4D runs are reduced to 3D references with `RobustAverage`.

Effectively, it reduces the runtime of the data I'm testing on (6 runs x 10 timepoints) from +3h down to 20 minutes.

Resolves: #279.