### PR TITLE
ENH: Make wrangler more verbose

### DIFF
--- a/sdcflows/cli/find_estimators.py
+++ b/sdcflows/cli/find_estimators.py
@@ -32,6 +32,12 @@ def _parser():
         help="Path to a PyBIDS database folder, for faster indexing (especially "
              "useful for large datasets). Will be created if not present."
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print information while finding estimators (Useful for debugging)",
+    )
     return parser
 
 
@@ -76,7 +82,7 @@ def main(argv=None):
     estimators_record = {}
     for subject in subjects:
         estimators_record[subject] = find_estimators(
-            layout=layout, subject=subject, fmapless=pargs.fmapless
+            layout=layout, subject=subject, fmapless=pargs.fmapless, verbose=pargs.verbose,
         )
 
     # pretty print results

--- a/sdcflows/cli/find_estimators.py
+++ b/sdcflows/cli/find_estimators.py
@@ -73,16 +73,21 @@ def main(argv=None):
     """
     from niworkflows.utils.bids import collect_participants
     from sdcflows.utils.wrangler import find_estimators
+    from sdcflows.utils.misc import create_logger
 
     pargs = _parser().parse_args(argv)
 
     bids_dir = pargs.bids_dir.resolve(strict=True)
     layout = gen_layout(bids_dir, pargs.bids_database_dir)
     subjects = collect_participants(layout, pargs.subjects)
+    logger = create_logger('sdcflow.wrangler', level=10 if pargs.verbose else 40)
     estimators_record = {}
     for subject in subjects:
         estimators_record[subject] = find_estimators(
-            layout=layout, subject=subject, fmapless=pargs.fmapless, verbose=pargs.verbose,
+            layout=layout,
+            subject=subject,
+            fmapless=pargs.fmapless,
+            logger=logger,
         )
 
     # pretty print results

--- a/sdcflows/utils/misc.py
+++ b/sdcflows/utils/misc.py
@@ -21,6 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Basic miscellaneous utilities."""
+import logging
 
 
 def front(inlist):
@@ -69,15 +70,15 @@ def get_free_mem():
         return None
 
 
-def create_logger(name: str, level: int = 40):
-    import logging
+def create_logger(name: str, level: int = 40) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(level)
-
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setLevel(level)
-        formatter = logging.Formatter('[%(name)s %(asctime)s] - %(levelname)s: %(message)s')
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
+    # clear any existing handlers
+    logger.handlers.clear()
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    # formatter = logging.Formatter('[%(name)s %(asctime)s] - %(levelname)s: %(message)s')
+    formatter = logging.Formatter('[%(name)s - %(levelname)s]: %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     return logger

--- a/sdcflows/utils/misc.py
+++ b/sdcflows/utils/misc.py
@@ -67,3 +67,17 @@ def get_free_mem():
         return round(virtual_memory().free, 1)
     except Exception:
         return None
+
+
+def create_logger(name: str, level: int = 40):
+    import logging
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(level)
+        formatter = logging.Formatter('[%(name)s %(asctime)s] - %(levelname)s: %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -29,8 +29,8 @@ from bids.layout import BIDSLayout
 from bids.utils import listify
 
 
-
-def find_estimators(*,
+def find_estimators(
+    *,
     layout: BIDSLayout,
     subject: str,
     sessions: Optional[List[str]] = None,
@@ -284,7 +284,10 @@ def find_estimators(*,
         has_B0FI = True
 
     if has_B0FI:
-        logger.debug("Dataset includes B0FieldIdentifier metadata. All `IntendedFor` metadata will be ignored.")
+        logger.debug(
+            "Dataset includes `B0FieldIdentifier` metadata."
+            "Any data missing this metadata will be ignored."
+        )
         for b0_id in b0_ids:
             # Found B0FieldIdentifier metadata entries
             b0_entities = base_entities.copy()

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -24,7 +24,7 @@
 from itertools import product
 from contextlib import suppress
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, List
 from bids.layout import BIDSLayout
 from bids.utils import listify
 
@@ -33,7 +33,7 @@ from bids.utils import listify
 def find_estimators(*,
     layout: BIDSLayout,
     subject: str,
-    sessions: Optional[list[str]] = None,
+    sessions: Optional[List[str]] = None,
     fmapless: Union[bool, set] = True,
     force_fmapless: bool = False,
     verbose: bool = False,

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -39,7 +39,7 @@ def find_estimators(
     sessions: Optional[List[str]] = None,
     fmapless: Union[bool, set] = True,
     force_fmapless: bool = False,
-    verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> list:
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.
@@ -66,8 +66,8 @@ def find_estimators(
     force_fmapless : :obj:`bool`
         When some other fieldmap estimation methods have been found, fieldmap-less
         estimation will be skipped except if ``force_fmapless`` is ``True``.
-    verbose
-        If enabled, display steps taken to find estimators.
+    logger
+        The logger used to relay messages. If not provided, one will be created.
 
     Returns
     -------
@@ -262,8 +262,8 @@ def find_estimators(
     from bids.layout import Query
     from bids.exceptions import BIDSEntityError
 
-    # Set up logger (logs only visable if verbose)
-    logger = create_logger('sdcflows.wrangler', level=10 if verbose else 40)
+    # The created logger is set to ERROR log level
+    logger = logger or create_logger('sdcflows.wrangler')
 
     base_entities = {
         "subject": subject,
@@ -280,12 +280,11 @@ def find_estimators(
     estimators = []
 
     # Step 1. Use B0FieldIdentifier metadata
-    has_B0FI = False
+    b0_ids = tuple()
     with suppress(BIDSEntityError):
         b0_ids = layout.get_B0FieldIdentifiers(**base_entities)
-        has_B0FI = True
 
-    if has_B0FI:
+    if b0_ids:
         logger.debug(
             "Dataset includes `B0FieldIdentifier` metadata."
             "Any data missing this metadata will be ignored."


### PR DESCRIPTION
Closes #283 

Adds `verbose` parameter, which enables logging through the `find_estimators()` process. 

I think this could also benefit from a way to visualize the layout, to further help debug why files are not being found.