### PR TITLE
ENH: Allow bids filtering during `get()` calls.

### DIFF
--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -106,8 +106,13 @@ phasediff = {
             "session": "01",
             "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
             "fmap": [
-                {"suffix": "phasediff", "metadata": {
-                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-01/func/sub-01_ses-01_task-rest_bold.nii.gz"}
+                {
+                    "suffix": "phasediff",
+                    "metadata": {
+                        "EchoTime1": 1.2,
+                        "EchoTime2": 1.4,
+                        "IntendedFor": "ses-01/func/sub-01_ses-01_task-rest_bold.nii.gz"
+                    }
                 },
                 {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
                 {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
@@ -128,8 +133,13 @@ phasediff = {
             "session": "02",
             "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
             "fmap": [
-                {"suffix": "phasediff", "metadata": {
-                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-02/func/sub-01_ses-02_task-rest_bold.nii.gz"}
+                {
+                    "suffix": "phasediff",
+                    "metadata": {
+                        "EchoTime1": 1.2,
+                        "EchoTime2": 1.4,
+                        "IntendedFor": "ses-02/func/sub-01_ses-02_task-rest_bold.nii.gz"
+                    }
                 },
                 {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
                 {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
@@ -150,8 +160,13 @@ phasediff = {
             "session": "03",
             "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
             "fmap": [
-                {"suffix": "phasediff", "metadata": {
-                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-03/func/sub-01_ses-03_task-rest_bold.nii.gz"}
+                {
+                    "suffix": "phasediff",
+                    "metadata": {
+                        "EchoTime1": 1.2,
+                        "EchoTime2": 1.4,
+                        "IntendedFor": "ses-03/func/sub-01_ses-03_task-rest_bold.nii.gz"
+                    }
                 },
                 {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
                 {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
@@ -174,20 +189,21 @@ phasediff = {
 
 filters = {
     "fmap": {
-            "datatype": "fmap",
-            "session": "01",
+        "datatype": "fmap",
+        "session": "01",
     },
     "t1w": {
-            "datatype": "anat",
-            "session": "01",
-            "suffix": "T1w"
+        "datatype": "anat",
+        "session": "01",
+        "suffix": "T1w"
     },
     "bold": {
-            "datatype": "func",
-            "session": "01",
-            "suffix": "bold"
+        "datatype": "func",
+        "session": "01",
+        "suffix": "bold"
     }
 }
+
 
 @pytest.mark.parametrize('name,skeleton,estimations', [
     ('pepolar', pepolar, 1),

--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -1,4 +1,3 @@
-from turtle import clear
 import pytest
 
 from niworkflows.utils.testing import generate_bids_skeleton

--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -1,0 +1,203 @@
+from turtle import clear
+import pytest
+
+from niworkflows.utils.testing import generate_bids_skeleton
+
+from sdcflows.cli.find_estimators import gen_layout
+from sdcflows.utils.wrangler import find_estimators
+from sdcflows.fieldmaps import clear_registry
+
+
+pepolar = {
+    "01": [
+        {
+            "session": "01",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "epi", "dir": "AP", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j-",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-01/func/sub-01_ses-01_task-rest_bold.nii.gz"
+                }},
+                {"suffix": "epi", "dir": "PA", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-01/func/sub-01_ses-01_task-rest_bold.nii.gz"
+                }}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        },
+        {
+            "session": "02",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "epi", "dir": "AP", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j-",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-02/func/sub-01_ses-02_task-rest_bold.nii.gz"
+                }},
+                {"suffix": "epi", "dir": "PA", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-02/func/sub-01_ses-02_task-rest_bold.nii.gz"
+                }}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        },
+        {
+            "session": "03",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "epi", "dir": "AP", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j-",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-03/func/sub-01_ses-03_task-rest_bold.nii.gz"
+                }},
+                {"suffix": "epi", "dir": "PA", "metadata": {
+                    "EchoTime": 1.2,
+                    "PhaseEncodingDirection": "j",
+                    "TotalReadoutTime": 0.8,
+                    "IntendedFor": "ses-03/func/sub-01_ses-03_task-rest_bold.nii.gz"
+                }}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+
+phasediff = {
+    "01": [
+        {
+            "session": "01",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "phasediff", "metadata": {
+                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-01/func/sub-01_ses-01_task-rest_bold.nii.gz"}
+                },
+                {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
+                {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        },
+        {
+            "session": "02",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "phasediff", "metadata": {
+                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-02/func/sub-01_ses-02_task-rest_bold.nii.gz"}
+                },
+                {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
+                {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        },
+        {
+            "session": "03",
+            "anat": [{"suffix": "T1w", "metadata": {"EchoTime": 1}}],
+            "fmap": [
+                {"suffix": "phasediff", "metadata": {
+                    "EchoTime1": 1.2, "EchoTime2": 1.4, "IntendedFor": "ses-03/func/sub-01_ses-03_task-rest_bold.nii.gz"}
+                },
+                {"suffix": "magnitude1", "metadata": {"EchoTime": 1.2}},
+                {"suffix": "magnitude2", "metadata": {"EchoTime": 1.4}}
+            ],
+            "func": [
+                {
+                    "task": "rest",
+                    "suffix": "bold",
+                    "metadata": {
+                        "RepetitionTime": 0.8,
+                        "TotalReadoutTime": 0.5,
+                        "PhaseEncodingDirection": "j"
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+
+filters = {
+    "fmap": {
+            "datatype": "fmap",
+            "session": "01",
+    },
+    "t1w": {
+            "datatype": "anat",
+            "session": "01",
+            "suffix": "T1w"
+    },
+    "bold": {
+            "datatype": "func",
+            "session": "01",
+            "suffix": "bold"
+    }
+}
+
+@pytest.mark.parametrize('name,skeleton,estimations', [
+    ('pepolar', pepolar, 1),
+    ('phasediff', phasediff, 1),
+])
+def test_wrangler_filter(tmpdir, name, skeleton, estimations):
+    bids_dir = str(tmpdir / name)
+    generate_bids_skeleton(bids_dir, skeleton)
+    layout = gen_layout(bids_dir)
+    est = find_estimators(layout=layout, subject='01', bids_filters=filters['fmap'])
+    assert len(est) == estimations
+    clear_registry()

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -40,6 +40,7 @@ def find_estimators(
     fmapless: Union[bool, set] = True,
     force_fmapless: bool = False,
     logger: Optional[logging.Logger] = None,
+    bids_filters: Optional[dict] = None,
 ) -> list:
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.
@@ -68,6 +69,9 @@ def find_estimators(
         estimation will be skipped except if ``force_fmapless`` is ``True``.
     logger
         The logger used to relay messages. If not provided, one will be created.
+    bids_filters
+        Optional dictionary of key/values to filter the entities on.
+        This allows lower level file inclusion/exclusion.
 
     Returns
     -------
@@ -261,6 +265,7 @@ def find_estimators(
     from .misc import create_logger
     from bids.layout import Query
     from bids.exceptions import BIDSEntityError
+    from bids.utils import listify
 
     # The created logger is set to ERROR log level
     logger = logger or create_logger('sdcflows.wrangler')
@@ -271,8 +276,16 @@ def find_estimators(
         "scope": "raw",  # Ensure derivatives are not captured
     }
 
+    if bids_filters:
+        from bids.utils import listify
+
+        if 'session' in bids_filters and sessions is not None:
+            raise ValueError("Filters include session, but session is already defined.")
+        sessions = listify(bids_filters.pop('session', None))
+        base_entities.update(bids_filters)
+
     subject_root = Path(layout.root) / f"sub-{subject}"
-    sessions = sessions or layout.get_sessions(subject=subject)
+    sessions = sessions or layout.get_sessions(subject=subject) or [None]
     fmapless = fmapless or {}
     if fmapless is True:
         fmapless = {"bold", "dwi"}
@@ -304,7 +317,9 @@ def find_estimators(
     # Step 2. If no B0FieldIdentifiers were found, try several heuristics
     if not estimators:
         # Set up B0 fieldmap strategies:
-        for fmap in layout.get(suffix=["fieldmap", "phasediff", "phase1"], **base_entities):
+        for fmap in layout.get(
+            **{**base_entities, **{'suffix': ["fieldmap", "phasediff", "phase1"], 'session': sessions}}
+        ):
             e = fm.FieldmapEstimation(
                 fm.FieldmapFile(fmap.path, metadata=fmap.get_metadata())
             )
@@ -312,10 +327,10 @@ def find_estimators(
             estimators.append(e)
 
         # A bunch of heuristics to select EPI fieldmaps
-        acqs = tuple(layout.get_acquisitions(subject=subject, suffix="epi") + [None])
-        contrasts = tuple(layout.get_ceagents(subject=subject, suffix="epi") + [None])
+        acqs = base_entities.get('acquisitions') or tuple(layout.get_acquisitions(subject=subject, suffix="epi") + [None])
+        contrasts = base_entities.get('ceagent') or tuple(layout.get_ceagents(subject=subject, suffix="epi") + [None])
 
-        for ses, acq, ce in product(sessions or (None,), acqs, contrasts):
+        for ses, acq, ce in product(sessions, acqs, contrasts):
             entities = base_entities.copy()
             entities.update(
                 {"suffix": "epi", "session": ses, "acquisition": acq, "ceagent": ce}
@@ -325,7 +340,7 @@ def find_estimators(
                 e = fm.FieldmapEstimation(
                     [
                         fm.FieldmapFile(fmap.path, metadata=fmap.get_metadata())
-                        for fmap in layout.get(direction=dirs, **entities)
+                        for fmap in layout.get(**{**entities, **{'direction': dirs}})
                     ]
                 )
                 _log_debug_estimation(logger, e, layout.root)
@@ -335,7 +350,7 @@ def find_estimators(
         # be automatically processed.
         has_intended = tuple()
         with suppress(ValueError):
-            has_intended = layout.get(suffix="epi", IntendedFor=Query.REQUIRED, **base_entities)
+            has_intended = layout.get(**{**base_entities, **{'suffix': 'epi', 'IntendedFor': Query.REQUIRED}})
 
         for epi_fmap in has_intended:
             if epi_fmap.path in fm._estimators.sources:
@@ -376,7 +391,7 @@ def find_estimators(
         fmapless = False
 
     # Find fieldmap-less schemes
-    anat_file = layout.get(suffix="T1w", **base_entities)
+    anat_file = layout.get(**{**base_entities, **{'suffix': 'T1w'}})
 
     if not fmapless or not anat_file:
         logger.debug("Skipping fmap-less estimation")
@@ -385,8 +400,8 @@ def find_estimators(
     logger.debug("Attempting fmap-less estimation")
     from .epimanip import get_trt
 
-    for ses, suffix in sorted(product(sessions or (None,), fmapless)):
-        candidates = layout.get(suffix=suffix, session=ses, **base_entities)
+    for ses, suffix in sorted(product(sessions, fmapless)):
+        candidates = layout.get(**{**base_entities, **{'suffix': suffix, 'session': ses}})
 
         # Filter out candidates without defined PE direction
         epi_targets = []

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -330,13 +330,11 @@ def find_estimators(
         # A bunch of heuristics to select EPI fieldmaps
         acqs = (
             base_entities.get('acquisitions')
-            or layout.get_acquisitions(subject=subject, suffix="epi")
-            or [None]
+            or layout.get_acquisitions(subject=subject, suffix="epi") + [None]
         )
         contrasts = (
             base_entities.get('ceagent')
-            or layout.get_ceagents(subject=subject, suffix="epi")
-            or [None]
+            or layout.get_ceagents(subject=subject, suffix="epi") + [None]
         )
         for ses, acq, ce in product(sessions, acqs, contrasts):
             entities = base_entities.copy()


### PR DESCRIPTION
This is to bring SDCFlow's file filtering more in-line with approaches taken in other nipreps. To avoid potential collisions during `get()` parameter assigment, base / additional values are first merged into a dictionary, and then passed in as keyword arguments