### PR TITLE
FIX: Calculate bspline grids separately from colocation matrices

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -156,17 +156,17 @@ class BSplineApprox(SimpleInterface):
         if need_resize:
             from sdcflows.utils.tools import resample_to_zooms
 
-            zooms_min = np.maximum(zooms, self.inputs.zooms_min)
+            target_zooms = np.maximum(zooms, self.inputs.zooms_min)
 
             LOGGER.info(
                 "Resampling image with resolution exceeding 'zooms_min' "
                 f"({'x'.join(str(s) for s in zooms)} → "
-                f"{'x'.join(str(s) for s in zooms_min)})."
+                f"{'x'.join(str(s) for s in target_zooms)})."
             )
-            fmapnii = resample_to_zooms(fmapnii, zooms_min)
+            fmapnii = resample_to_zooms(fmapnii, target_zooms)
 
             if masknii is not None:
-                masknii = resample_to_zooms(masknii, zooms_min)
+                masknii = resample_to_zooms(masknii, target_zooms)
 
         data = fmapnii.get_fdata(dtype="float32")
 


### PR DESCRIPTION
The `_collocation_matrix` function introduced in #301 could produce slightly different knot spacings if the field of view changes sufficiently in resampling. The results of this function should be based entirely on the size of the input image, not a dynamic resampling.

We therefore calculate the grid spacings before any resampling. This eliminates the need for a separate `_collocation_matrix`, which can be done with a single call to `scipy.sparse.vstack()` over an iterable of sparse matrices.

Closes #307.