### PR TITLE
CI: Roll unittests runner back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-linux:
     if: "!contains(github.event.head_commit.message, '[skip ci]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'nipreps/sdcflows'))"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       TEST_DATA_HOME: /home/runner/sdcflows-tests
       FSLDIR: /usr/share/fsl/5.0


### PR DESCRIPTION
GitHub picked a bad time to upgrade `ubuntu-latest` to 22.04.