### PR TITLE
ENH: Drop n_procs tag from BSplineApprox

### DIFF
--- a/sdcflows/workflows/fit/fieldmap.py
+++ b/sdcflows/workflows/fit/fieldmap.py
@@ -99,7 +99,7 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     )
 
     magnitude_wf = init_magnitude_wf(omp_nthreads=omp_nthreads)
-    bs_filter = pe.Node(BSplineApprox(), n_procs=omp_nthreads, name="bs_filter")
+    bs_filter = pe.Node(BSplineApprox(), name="bs_filter")
     bs_filter.interface._always_run = debug
     bs_filter.inputs.bs_spacing = (
         [DEFAULT_LF_ZOOMS_MM, DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -267,7 +267,7 @@ template [@fieldmapless3].
     )
 
     # Regularize with B-Splines
-    bs_filter = pe.Node(BSplineApprox(), n_procs=omp_nthreads, name="bs_filter")
+    bs_filter = pe.Node(BSplineApprox(), name="bs_filter")
     bs_filter.interface._always_run = debug
     bs_filter.inputs.bs_spacing = (
         [DEFAULT_LF_ZOOMS_MM, DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]


### PR DESCRIPTION
BSplineApprox does not make use of multiple processors by default or accept them as an option.