### PR TITLE
FIX: Collate fieldmap coefficients into list of lists

### DIFF
--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -87,11 +87,15 @@ def init_fmap_preproc_wf(
 
     workflow = Workflow(name=name)
 
-    out_fields = ("fmap", "fmap_ref", "fmap_coeff", "fmap_mask", "fmap_id", "method")
+    out_fields = ("fmap", "fmap_coeff", "fmap_ref", "fmap_mask", "fmap_id", "method")
     out_merge = {
         f: pe.Node(niu.Merge(len(estimators)), name=f"out_merge_{f}")
         for f in out_fields
     }
+    # Fieldmaps and coefficient files can come in pairs, ensure they are not flattened
+    out_merge["fmap"].inputs.no_flatten = True
+    out_merge["fmap_coeff"].inputs.no_flatten = True
+
     outputnode = pe.Node(niu.IdentityInterface(fields=out_fields), name="outputnode")
 
     workflow.connect(

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -62,5 +62,15 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
     if workdir:
         wf.base_dir = str(workdir)
 
-    if os.getenv("GITHUB_ACTIONS") != "true":
-        wf.run(plugin="Linear")
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        return
+
+    res = wf.run(plugin="Linear")
+
+    # Regression test for when out_merge_fmap_coeff was flattened and would
+    # have twice as many elements as the other nodes
+    assert all(
+        len(node.result.outputs.out) == len(estimators)
+        for node in res.nodes
+        if node.name.startswith("out_merge_")
+    )


### PR DESCRIPTION
Currently the fieldmap coeffficients from each estimator are aggregated into a single list. When selected by downstream nodes, the first application node gets the first coefficient of the first estimator, the second application node gets the second coefficient of the first estimator, the third application node gets the first coefficient of the second estimator, and so on.

This has been obscured from using test datasets with only one estimator, so only the low frequency components are getting applied.

This PR simply prevents this list from being flattened. Will test with downstream to make sure a list of coefficients can be passed.

```RST
Node: single_subject_EB_wf (fmap_preproc_wf (out_merge_fmap_coeff (utility)
===========================================================================


 Hierarchy : fmriprep_0_0_wf.single_subject_EB_wf.fmap_preproc_wf.out_merge_fmap_coeff
 Exec ID : out_merge_fmap_coeff


Original Inputs
---------------


* axis : vstack
* in1 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in2 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in3 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in4 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* no_flatten : False
* ravel_inputs : False


Execution Inputs
----------------


* axis : vstack
* in1 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in2 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in3 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* in4 : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
* no_flatten : False
* ravel_inputs : False


Execution Outputs
-----------------


* out : ['/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00000/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00001/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00002/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff000.nii.gz', '/scratch/fmriprep_0_0_wf/single_subject_EB_wf/fmap_preproc_wf/wf_auto_00003/bs_filter/fmap_syn0Warp_Hz_trans_coeff001.nii.gz']
```