### PR TITLE
FIX: Pad BSpline design matrix

### DIFF
--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -406,13 +406,15 @@ def grid_bspline_weights(target_nii, ctrl_nii, dtype="float32"):
 
         # Calculate the index component of samples w.r.t. B-Spline knots along current axis
         x = nb.affines.apply_affine(target_to_grid, coords.T)[:, axis]
+        pad_left = max(int(-np.rint(x.min())), 0)
+        pad_right = max(int(np.rint(x.max()) - knots_shape[axis]), 0)
 
         # BSpline.design_matrix requires all x be within -4 and 4 padding
         # This padding results from the B-Spline degree (3) plus one
-        t = np.arange(-4, knots_shape[axis] + 4, dtype=dtype)
+        t = np.arange(-4 - pad_left, knots_shape[axis] + 4 + pad_right, dtype=dtype)
 
         # Calculate K x N collocation matrix (discarding extra padding)
-        colloc_ax = BSpline.design_matrix(x, t, 3)[:, 2:-2]
+        colloc_ax = BSpline.design_matrix(x, t, 3)[:, (2 + pad_left):-(2 + pad_right)]
         # Design matrix returns K x N and we want N x K
         wd.append(colloc_ax.T.tocsr())
 


### PR DESCRIPTION
If the bounding box of the target image goes outside the bounding box of the B-spline coefficient image, scipy will refuse to construct a design matrix. This is because the coordinates `x` (voxel indices translated into non-integral indices in the coefficient image's voxel space) may go below 0 or above the number of knots.

This PR aims to work around this limitation without changing the logic on the grounds that we need the best approximation of the field at all locations within the target image. At the edges, the field is likely to get masked out anyway. This assumes that the fieldmap and target image are in register and the differences in their affines reflect real differences in FoV.

We have a default padding of 4 knots in each direction, which gets reduced to 2 by `BSpline.design_matrix`. This adds in a padding based on the min/max values of `x`. The padding is added to `t` and then removed from the design matrix to ensure that the weights still correspond to the coefficients stored in the coefficient images.