### PR TITLE
RF: Generate the b-spline design matrix directly for efficiency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 
 # Mac OSX
 .DS_Store
+
+.*.swp
+line-contributors.txt

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -28,7 +28,7 @@ import numpy as np
 from warnings import warn
 from scipy import ndimage as ndi
 from scipy.signal import cubic
-from scipy.sparse import vstack as sparse_vstack, kron, csr_matrix, lil_matrix
+from scipy.sparse import vstack as sparse_vstack, kron, lil_array
 
 import nibabel as nb
 import nitransforms as nt
@@ -413,10 +413,10 @@ def grid_bspline_weights(target_nii, ctrl_nii, dtype="float32"):
         d_vals, d_idxs = np.unique(distance[within_support], return_inverse=True)
         bs_w = cubic(d_vals)
 
-        colloc_ax = lil_matrix((knots_shape[axis], sample_shape[axis]), dtype=dtype)
+        colloc_ax = lil_array((knots_shape[axis], sample_shape[axis]), dtype=dtype)
         colloc_ax[within_support] = bs_w[d_idxs]
 
-        wd.append(csr_matrix(colloc_ax))
+        wd.append(colloc_ax)
 
     # Calculate the tensor product of the three design matrices
     return kron(kron(wd[0], wd[1]), wd[2]).astype(dtype)

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -27,8 +27,8 @@ import attr
 import numpy as np
 from warnings import warn
 from scipy import ndimage as ndi
-from scipy.interpolate import BSpline
-from scipy.sparse import vstack as sparse_vstack, kron
+from scipy.signal import cubic
+from scipy.sparse import vstack as sparse_vstack, kron, csr_matrix, lil_matrix
 
 import nibabel as nb
 import nitransforms as nt
@@ -405,18 +405,18 @@ def grid_bspline_weights(target_nii, ctrl_nii, dtype="float32"):
         coords[axis] = np.arange(sample_shape[axis], dtype=dtype)
 
         # Calculate the index component of samples w.r.t. B-Spline knots along current axis
-        x = nb.affines.apply_affine(target_to_grid, coords.T)[:, axis]
-        pad_left = max(int(-np.rint(x.min())), 0)
-        pad_right = max(int(np.rint(x.max()) - knots_shape[axis]), 0)
+        locs = nb.affines.apply_affine(target_to_grid, coords.T)[:, axis]
+        knots = np.arange(knots_shape[axis], dtype=dtype)
 
-        # BSpline.design_matrix requires all x be within -4 and 4 padding
-        # This padding results from the B-Spline degree (3) plus one
-        t = np.arange(-4 - pad_left, knots_shape[axis] + 4 + pad_right, dtype=dtype)
+        distance = np.abs(locs[np.newaxis, ...] - knots[..., np.newaxis])
+        within_support = distance < 2.0
+        d_vals, d_idxs = np.unique(distance[within_support], return_inverse=True)
+        bs_w = cubic(d_vals)
 
-        # Calculate K x N collocation matrix (discarding extra padding)
-        colloc_ax = BSpline.design_matrix(x, t, 3)[:, (2 + pad_left):-(2 + pad_right)]
-        # Design matrix returns K x N and we want N x K
-        wd.append(colloc_ax.T.tocsr())
+        colloc_ax = lil_matrix((knots_shape[axis], sample_shape[axis]), dtype=dtype)
+        colloc_ax[within_support] = bs_w[d_idxs]
+
+        wd.append(csr_matrix(colloc_ax))
 
     # Calculate the tensor product of the three design matrices
     return kron(kron(wd[0], wd[1]), wd[2]).astype(dtype)


### PR DESCRIPTION
Fixes #323. Avoids scipy checks, though those might be pointing out problems in our ranges.

Includes a test to ensure we're getting the same result back for at least a straightforward case.

Using example data provided in #323, I've determined that the issue was with rounding toward zero instead of away from causing off-by-one errors in padding in some cases. However, that same data shows that the obvious fix leads to 1.5s runtime as opposed to 350ms with this patch. The time is almost entirely spent in `kron()`, so the explanation is probably the 2-knot cutoff. The difference between the constructed arrays is <1e-7 everywhere.

I've also done some fiddling with the choice of sparse matrices. Using `lil_array` allows for straightforward matrix construction using the mask. Coercing `kron` to output to something other than `coo` does not provide any improvements.