### PR TITLE
FIX: Remove unused ANTs parameter that was removed in 2.4.1

### DIFF
--- a/sdcflows/data/affine.json
+++ b/sdcflows/data/affine.json
@@ -16,7 +16,6 @@
     "smoothing_sigmas": [ [ 6, 0 ], [ 2, 1 ] ],
     "transform_parameters": [ [ 2.0 ], [ 1.0 ] ],
     "transforms": [ "Rigid", "Affine" ],
-    "use_estimate_learning_rate_once": [ false, false ],
     "use_histogram_matching": [ true, true ],
     "winsorize_lower_quantile": 0.001,
     "winsorize_upper_quantile": 0.998,

--- a/sdcflows/data/fmap-any_registration.json
+++ b/sdcflows/data/fmap-any_registration.json
@@ -16,7 +16,6 @@
     "smoothing_sigmas": [ [ 8.0 ], [ 2.0 ] ],
     "transform_parameters": [ [ 0.1 ], [ 0.1 ] ],
     "transforms": [ "Rigid", "Rigid" ],
-    "use_estimate_learning_rate_once": [ true, false ],
     "use_histogram_matching": [ true, true ],
     "winsorize_lower_quantile": 0.001,
     "winsorize_upper_quantile": 0.999

--- a/sdcflows/data/fmap-any_registration_testing.json
+++ b/sdcflows/data/fmap-any_registration_testing.json
@@ -16,7 +16,6 @@
     "smoothing_sigmas": [ [ 8.0 ], [ 2.0 ] ],
     "transform_parameters": [ [ 1.0 ], [ 0.5 ] ],
     "transforms": [ "Rigid", "Rigid" ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "winsorize_lower_quantile": 0.005,
     "winsorize_upper_quantile": 0.998

--- a/sdcflows/data/sd_syn.json
+++ b/sdcflows/data/sd_syn.json
@@ -16,7 +16,6 @@
     "smoothing_sigmas": [ [ 2, 0 ], [ 0 ] ],
     "transform_parameters": [ [ 0.8, 6.0, 3.0 ], [ 0.8, 2.0, 1.0 ] ],
     "transforms": [ "SyN", "SyN" ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "winsorize_lower_quantile": 0.001,
     "winsorize_upper_quantile": 0.998,

--- a/sdcflows/data/sd_syn_sloppy.json
+++ b/sdcflows/data/sd_syn_sloppy.json
@@ -16,7 +16,6 @@
     "smoothing_sigmas": [ [ 2, 0 ], [ 0 ] ],
     "transform_parameters": [ [ 0.8, 6.0, 3.0 ], [ 0.8, 2.0, 1.0 ] ],
     "transforms": [ "SyN", "SyN" ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "verbose": true,
     "winsorize_lower_quantile": 0.001,

--- a/sdcflows/data/translation_rigid.json
+++ b/sdcflows/data/translation_rigid.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Translation", "Rigid" ],
     "number_of_iterations": [ [ 500 ], [ 200 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],


### PR DESCRIPTION
`--use-estimate-learning-rate-once` was removed in https://github.com/ANTsX/ANTs/pull/1411 (released v2.4.1). It seems it has had no effect for some time (I think since v2.0.0).