### PR TITLE
FIX: Remove unused ANTs parameter that was removed in 2.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,14 +131,13 @@ jobs:
                    --exclude='freesurfer/subjects/sample-*.mgz' \
                    --exclude='freesurfer/subjects/V1_average' \
                    --exclude='freesurfer/trctrain'
-              pushd /tmp/freesurfer
-              echo "${FS_LICENSE_CONTENT}" | base64 -d | sh
+              echo "b2VzdGViYW5Ac3RhbmZvcmQuZWR1CjMwNzU2CiAqQ1MzYkJ5VXMxdTVNCiBGU2kvUGJsejJxR1V3Cg==" | base64 -d > /tmp/freesurfer/license.txt
             else
               echo "FreeSurfer was cached."
               circleci step halt
             fi
       - save_cache:
-          key: freesurfer-v1-{{ .BuildNum }}
+          key: freesurfer-v0-{{ .BuildNum }}
           paths:
             - /tmp/freesurfer
 

--- a/sdcflows/data/affine.json
+++ b/sdcflows/data/affine.json
@@ -6,7 +6,6 @@
     "winsorize_upper_quantile": 0.995,
     "collapse_output_transforms": true,
     "use_histogram_matching": [ false, false ],
-    "use_estimate_learning_rate_once": [ false, false ],
     "transforms": [ "Rigid", "Affine" ],
     "number_of_iterations": [ [ 1000, 500, 250, 100 ], [ 1000, 500, 250, 100 ] ],
     "transform_parameters": [ [ 0.1 ], [ 0.1 ] ],

--- a/sdcflows/data/fmap-any_registration.json
+++ b/sdcflows/data/fmap-any_registration.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Translation", "Affine" ],
     "number_of_iterations": [ [ 500 ], [ 200 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],

--- a/sdcflows/data/fmap-any_registration_testing.json
+++ b/sdcflows/data/fmap-any_registration_testing.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Rigid", "Rigid" ],
     "number_of_iterations": [ [ 500 ], [ 100 ] ],
     "transform_parameters": [ [ 1.0 ], [ 0.5 ] ],

--- a/sdcflows/data/susceptibility_syn.json
+++ b/sdcflows/data/susceptibility_syn.json
@@ -14,7 +14,6 @@
     "shrink_factors": [ [ 2, 1 ], [ 1, 1 ] ],
     "winsorize_upper_quantile": 1.0,
     "winsorize_lower_quantile": 0.001,
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/sdcflows/data/translation_rigid.json
+++ b/sdcflows/data/translation_rigid.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Translation", "Rigid" ],
     "number_of_iterations": [ [ 500 ], [ 200 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],


### PR DESCRIPTION
Backport of #330 (and #329) in passing.