### PR TITLE
ENH: Calculate fieldwarps in reference space in unwarp_wf

### DIFF
--- a/sdcflows/workflows/apply/tests/test_correction.py
+++ b/sdcflows/workflows/apply/tests/test_correction.py
@@ -60,7 +60,10 @@ def test_unwarp_wf(tmpdir, datadir, workdir, outdir):
     workflow = pe.Workflow(name="test_unwarp_wf")
     # fmt: off
     workflow.connect([
-        (epi_ref_wf, unwarp_wf, [("outputnode.fmap_ref", "inputnode.distorted")]),
+        (epi_ref_wf, unwarp_wf, [
+            ("outputnode.fmap_ref", "inputnode.distorted"),
+            ("outputnode.fmap_ref", "inputnode.distorted_ref"),
+        ]),
         (epi_ref_wf, reg_wf, [
             ("outputnode.fmap_ref", "inputnode.target_ref"),
             ("outputnode.fmap_mask", "inputnode.target_mask"),


### PR DESCRIPTION
Fixes #333.

This is more a bug in fmriprep than in sdcflows proper.