### PR TITLE
REL: 2.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+2.3.0 (March 01, 2023)
+======================
+New feature release in the 2.3.x series.
+
+This release supports fMRIPrep 23.0.x and Nibabies 23.0.x.
+
+* ENH: Calculate fieldwarps in reference space in unwarp_wf (#334)
+* TEST: Squeeze image before passing to SimpleBeforeAfter (#337)
+* MAINT: Rotate CircleCI secrets and setup up org-level context (#329)
+* CI: Run unit tests on Python 3.10 (#326)
+* CI: Switch to miniconda setup, install fsl tools through conda (#322)
+
 2.2.2 (January 04, 2023)
 ========================
 Patch release in the 2.2.x series.


### PR DESCRIPTION
Release prep for 2.3.0.

I think it should probably be 2.3.0 because of #334, but strictly that adds nodes to a workflow, but does not change any existing connections. This could be 2.2.3, if people would rather not crank the version and possibly need to maintain `maint/2.2.x` separately.

Ping @mgxd and @oesteban for comments.