### PR TITLE
 ENH: allow non-T1w anatomical estimators

### DIFF
--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -74,6 +74,9 @@ def find_estimators(
     bids_filters
         Optional dictionary of key/values to filter the entities on.
         This allows lower level file inclusion/exclusion.
+    anat_suffix : :obj:`str` or :obj:`list`
+        String or list of strings to filter anatomical images for fieldmap-less
+        approaches. If not provided, ``T1w`` is used.
 
     Returns
     -------

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -42,7 +42,7 @@ def find_estimators(
     force_fmapless: bool = False,
     logger: Optional[logging.Logger] = None,
     bids_filters: Optional[dict] = None,
-    anat_suffix: Union[str, list] = 'T1w',
+    anat_suffix: Union[str, List[str]] = 'T1w',
 ) -> list:
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -42,7 +42,7 @@ def find_estimators(
     force_fmapless: bool = False,
     logger: Optional[logging.Logger] = None,
     bids_filters: Optional[dict] = None,
-    anat_suffix='T1w'
+    anat_suffix: Union[str, list] = 'T1w',
 ) -> list:
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -42,6 +42,7 @@ def find_estimators(
     force_fmapless: bool = False,
     logger: Optional[logging.Logger] = None,
     bids_filters: Optional[dict] = None,
+    anat_suffix='T1w'
 ) -> list:
     """
     Apply basic heuristics to automatically find available data for fieldmap estimation.
@@ -467,7 +468,7 @@ def find_estimators(
         fmapless = False
 
     # Find fieldmap-less schemes
-    anat_file = layout.get(**{**base_entities, **{'suffix': 'T1w', 'session': sessions}})
+    anat_file = layout.get(**{**base_entities, **{'suffix': anat_suffix, 'session': sessions}})
 
     if not fmapless or not anat_file:
         logger.debug("Skipping fmap-less estimation")


### PR DESCRIPTION
Anatomical reference images are less likely to be T1w in rodents. This would allow nipreps/fmriprep-rodents#55 the flexibility to provide a list of possible contrasts for anatomical images (in this case: T1w, T2w, UNIT1) to be used as an anatomical reference image without breaking compatibility for other use cases.