### PR TITLE
FIX: do not omit session bids_filter when listing b0 ids

### DIFF
--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -317,9 +317,10 @@ def find_estimators(
             b0_entities = base_entities.copy()
             b0_entities["B0FieldIdentifier"] = b0_id
 
-            bare_ids = layout.get(**base_entities, B0FieldIdentifier=b0_id)
+            bare_ids = layout.get(**base_entities, session=sessions, B0FieldIdentifier=b0_id)
             listed_ids = layout.get(
                 **base_entities,
+                session=sessions,
                 B0FieldIdentifier=f'"{b0_id}"',  # Double quotes to match JSON, not Python repr
                 regex_search=True,
             )


### PR DESCRIPTION
When running fMRIPrep on a single session (using bids filters), the wrangler will try to create fieldmap estimators from other session, and crash if data is not present (eg. datalad symlinks). 
This fix should prevent such crash.