### PR TITLE
RF/FIX: Prioritize sbref and shortest echo for SyN-SDC

### DIFF
--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -286,6 +286,10 @@ def test_fieldmapless(tmp_path):
             "PhaseEncodingDirection": "j",
         },
     }
+    me_metadata = [
+        {"EchoTime": 0.01 * i, **bold["metadata"]}
+        for i in range(1, 4)
+    ]
     sbref = {**bold, **{"suffix": "sbref"}}
     spec = {
         "01": {
@@ -320,7 +324,7 @@ def test_fieldmapless(tmp_path):
     spec = {
         "01": {
             "anat": [T1w],
-            "func": [{"echo": i, **bold} for i in range(1, 4)],
+            "func": [{"echo": i + 1, **bold, **{"metadata": me_metadata[i]}} for i in range(3)],
         },
     }
     generate_bids_skeleton(bids_dir, spec)
@@ -365,8 +369,8 @@ def test_fieldmapless(tmp_path):
     spec = {
         "01": {
             "anat": [T1w],
-            "func": [{"echo": i, **bold} for i in range(1, 4)]
-            + [{"echo": i, **sbref} for i in range(1, 4)],
+            "func": [{"echo": i + 1, **bold, **{"metadata": me_metadata[i]}} for i in range(3)] +
+            [{"echo": i + 1, **sbref, **{"metadata": me_metadata[i]}} for i in range(3)],
         },
     }
     generate_bids_skeleton(bids_dir, spec)

--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -369,8 +369,14 @@ def test_fieldmapless(tmp_path):
     spec = {
         "01": {
             "anat": [T1w],
-            "func": [{"echo": i + 1, **bold, **{"metadata": me_metadata[i]}} for i in range(3)] +
-            [{"echo": i + 1, **sbref, **{"metadata": me_metadata[i]}} for i in range(3)],
+            "func": [
+                {"echo": i + 1, **bold, **{"metadata": me_metadata[i]}}
+                for i in range(3)
+            ]
+            + [
+                {"echo": i + 1, **sbref, **{"metadata": me_metadata[i]}}
+                for i in range(3)
+            ],
         },
     }
     generate_bids_skeleton(bids_dir, spec)

--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -326,7 +326,7 @@ def test_fieldmapless(tmp_path):
     generate_bids_skeleton(bids_dir, spec)
     layout = gen_layout(bids_dir)
     est = find_estimators(layout=layout, subject="01", fmapless=True)
-    assert len(est) == 3  # Should be 1
+    assert len(est) == 1
     assert len(est[0].sources) == 2
     clear_registry()
     rmtree(bids_dir)
@@ -341,7 +341,7 @@ def test_fieldmapless(tmp_path):
     generate_bids_skeleton(bids_dir, spec)
     layout = gen_layout(bids_dir)
     est = find_estimators(layout=layout, subject="01", fmapless=True)
-    assert len(est) == 2  # Should be 1
+    assert len(est) == 1
     assert len(est[0].sources) == 2
     clear_registry()
     rmtree(bids_dir)
@@ -372,7 +372,7 @@ def test_fieldmapless(tmp_path):
     generate_bids_skeleton(bids_dir, spec)
     layout = gen_layout(bids_dir)
     est = find_estimators(layout=layout, subject="01", fmapless=True)
-    assert len(est) == 6  # Should be 1
+    assert len(est) == 1
     assert len(est[0].sources) == 2
     clear_registry()
     rmtree(bids_dir)

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -500,22 +500,17 @@ def find_estimators(
 
         # Filter out candidates without defined PE direction
         epi_targets = []
-        pe_dirs = []
-        ro_totals = []
 
         for candidate in candidates:
             meta = candidate.get_metadata()
-            pe_dir = meta.get("PhaseEncodingDirection")
 
-            if not pe_dir:
+            if not meta.get("PhaseEncodingDirection"):
                 continue
 
-            pe_dirs.append(pe_dir)
-            ro = 1.0
+            trt = 1.0
             with suppress(ValueError):
-                ro = get_trt(meta, candidate.path)
-            ro_totals.append(ro)
-            meta.update({"TotalReadoutTime": ro})
+                trt = get_trt(meta, candidate.path)
+            meta.update({"TotalReadoutTime": trt})
             epi_targets.append(fm.FieldmapFile(candidate.path, metadata=meta))
 
         trivial_estimators = [


### PR DESCRIPTION
This PR resolves the twin issues of either creating an estimator per echo or including all echos (with different contrast and dropout properties) in multi-echo SyN.

Because we want the shortest echo, the simplest way to do this was to sort all possible EPIs by suffix and echo time, to push the shortest echo sbref to the front of the line, or the shortest echo bold/dwi, failing that. We then set "IntendedFor" to the set of sbrefs/echos matching all other entities/path components. Keeping track of what files have been included in an "IntendedFor" avoids finding multiple estimators for a set.

New estimator results:

```
❯ sdcflows-find-estimators --subject 02 --fmapless . 
Estimation for </data/openneuro/ds000210> complete. Found:
	sub-02
		FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>, bids_id='auto_00000')
			None	anat/sub-02_T1w.nii.gz
			j	func/sub-02_task-cuedSGT_run-01_echo-1_bold.nii.gz
		FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>, bids_id='auto_00001')
			None	anat/sub-02_T1w.nii.gz
			j	func/sub-02_task-cuedSGT_run-02_echo-1_bold.nii.gz
		FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>, bids_id='auto_00002')
			None	anat/sub-02_T1w.nii.gz
			j	func/sub-02_task-cuedSGT_run-03_echo-1_bold.nii.gz
		FieldmapEstimation(sources=<2 files>, method=<EstimatorType.ANAT: 5>, bids_id='auto_00003')
			None	anat/sub-02_T1w.nii.gz
			j	func/sub-02_task-cuedSGT_run-04_echo-1_bold.nii.gz
```

Closes #363.