### PR TITLE
FIX: Ensure metadata is not present in entities

### DIFF
--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -441,7 +441,7 @@ def find_estimators(
                 targets = sbrefs
                 intent_map = []
                 for sbref in sbrefs:
-                    ents = sbref.entities.copy()
+                    ents = sbref.get_entities(metadata=False)
                     ents["suffix"] = ["bold", "dwi"]
                     intent_map.append(
                         [


### PR DESCRIPTION
`BIDSImageFile.entities` populates both filename and metadata entities, which can result in an overzealous SQL join resulting in:
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) at most 64 tables in a join
```

This change ensures metadata is not present when filtering.
