### PR TITLE
FIX: Make call to scipy.stats.mode compatible with scipy 1.11.0

### DIFF
--- a/sdcflows/workflows/gre.py
+++ b/sdcflows/workflows/gre.py
@@ -212,7 +212,7 @@ def _demean(in_file, in_mask=None, usemode=True):
 
     if usemode:
         from scipy.stats import mode
-        data[msk] -= mode(data[msk], axis=None)[0][0]
+        data[msk] -= mode(data[msk], axis=None).mode.item()
     else:
         data[msk] -= np.median(data[msk], axis=None)
 


### PR DESCRIPTION
Starting with scipy 1.11.0, scipy.stats.mode returns a scalar value for the mode instead of a one-element array. This change was foreshadowed in scipy version 1.9.0 with the addition of the `keepdims` parameter, with the eventual goal of setting it to false by default for consistency with other scipy.stats functions.
See https://github.com/scipy/scipy/issues/16418 for the initial proposal and https://github.com/scipy/scipy/pull/17561 for the final change that is now breaking the _demean function.

This commit changes the indexing to be compatible with scipy 1.11.0 and other future versions. I have also tested this change with older scipy versions up to 0.17.1, which was released in 2016.