### PR TITLE
DOC: Fix missing dependency when merging new data loader

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 attrs >= 20.1.0
 furo
+importlib_resources
 matplotlib >= 2.2.0
 nibabel
 nipype >= 1.5.1


### PR DESCRIPTION
I introduced this issue with the rushed merge of #379. 