### PR TITLE
ENH: Allow unwarp to apply only to references

### DIFF
--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -86,7 +86,6 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
         No motion is taken into account.
 
     """
-    from niworkflows.interfaces.images import RobustAverage
     from niworkflows.interfaces.nibabel import MergeSeries
     from sdcflows.interfaces.epi import GetReadoutTime
     from sdcflows.interfaces.bspline import ApplyCoeffsField
@@ -135,15 +134,23 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
 
     # fmt:off
     workflow.connect([
-        (inputnode, rotime, [(("distorted", _pop), "in_file"),
-                             ("metadata", "metadata")]),
-        (inputnode, resample_ref, [("distorted_ref", "in_data"),
-                                   ("fmap_coeff", "in_coeff")]),
-        (rotime, resample_ref, [("readout_time", "ro_time"),
-                                ("pe_direction", "pe_dir")]),
+        (inputnode, rotime, [
+            (("distorted", _pop), "in_file"),
+            ("metadata", "metadata"),
+        ]),
+        (inputnode, resample_ref, [
+            ("distorted_ref", "in_data"),
+            ("fmap_coeff", "in_coeff"),
+        ]),
+        (rotime, resample_ref, [
+            ("readout_time", "ro_time"),
+            ("pe_direction", "pe_dir"),
+        ]),
         (resample_ref, brainextraction_wf, [("out_corrected", "inputnode.in_file")]),
-        (resample_ref, outputnode, [("out_field", "fieldmap_ref"),
-                                    ("out_warp", "fieldwarp_ref")]),
+        (resample_ref, outputnode, [
+            ("out_field", "fieldmap_ref"),
+            ("out_warp", "fieldwarp_ref"),
+        ]),
         (brainextraction_wf, outputnode, [
             ("outputnode.out_file", "corrected_ref"),
             ("outputnode.out_mask", "corrected_mask"),
@@ -162,15 +169,21 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
 
         # fmt:off
         workflow.connect([
-            (inputnode, resample, [("distorted", "in_data"),
-                                ("fmap_coeff", "in_coeff"),
-                                ("hmc_xforms", "in_xfms")]),
-            (rotime, resample, [("readout_time", "ro_time"),
-                                ("pe_direction", "pe_dir")]),
+            (inputnode, resample, [
+                ("distorted", "in_data"),
+                ("fmap_coeff", "in_coeff"),
+                ("hmc_xforms", "in_xfms"),
+            ]),
+            (rotime, resample, [
+                ("readout_time", "ro_time"),
+                ("pe_direction", "pe_dir"),
+            ]),
             (resample, merge, [("out_corrected", "in_files")]),
             (merge, outputnode, [("out_file", "corrected")]),
-            (resample, outputnode, [("out_field", "fieldmap"),
-                                    ("out_warp", "fieldwarp")]),
+            (resample, outputnode, [
+                ("out_field", "fieldmap"),
+                ("out_warp", "fieldwarp"),
+            ]),
         ])
         # fmt:on
     return workflow

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -26,7 +26,9 @@ from nipype.interfaces import utility as niu
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 
-def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False, name="unwarp_wf"):
+def init_unwarp_wf(
+    *, ref_only=False, free_mem=None, omp_nthreads=1, debug=False, name="unwarp_wf",
+):
     r"""
     Set up a workflow that unwarps the input :abbr:`EPI (echo-planar imaging)` dataset.
 
@@ -95,7 +97,13 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["distorted", "distorted_ref", "metadata", "fmap_coeff", "hmc_xforms"]
+            fields=[
+                "distorted",
+                "distorted_ref",
+                "metadata",
+                "fmap_coeff",
+                "hmc_xforms",
+            ]
         ),
         name="inputnode",
     )
@@ -128,7 +136,9 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
     else:
         num_threads = omp_nthreads
 
-    resample_ref = pe.Node(ApplyCoeffsField(), mem_gb=mem_per_thread, name="resample_ref")
+    resample_ref = pe.Node(
+        ApplyCoeffsField(), mem_gb=mem_per_thread, name="resample_ref"
+    )
 
     brainextraction_wf = init_brainextraction_wf()
 

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -159,7 +159,6 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
         )
 
         merge = pe.Node(MergeSeries(), name="merge")
-        average = pe.Node(RobustAverage(mc_method=None), name="average")
 
         # fmt:off
         workflow.connect([
@@ -169,7 +168,6 @@ def init_unwarp_wf(*, ref_only=False, free_mem=None, omp_nthreads=1, debug=False
             (rotime, resample, [("readout_time", "ro_time"),
                                 ("pe_direction", "pe_dir")]),
             (resample, merge, [("out_corrected", "in_files")]),
-            (merge, average, [("out_file", "in_file")]),
             (merge, outputnode, [("out_file", "corrected")]),
             (resample, outputnode, [("out_field", "fieldmap"),
                                     ("out_warp", "fieldwarp")]),


### PR DESCRIPTION
This PR adds a `ref_only` mode to `init_unwarp_wf` that allows the same workflow to be used only on reference volumes.

This also changes the output reference volume to be derived from the input reference volume, rather than the average of the corrected time series.