### PR TITLE
RF: Use scipy.interpolate.BSpline to construct spline basis

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -130,7 +130,7 @@ class BSplineApprox(SimpleInterface):
 
     def _run_interface(self, runtime):
         from sklearn import linear_model as lm
-        from scipy.sparse import vstack as sparse_vstack
+        from scipy.sparse import hstack as sparse_hstack
 
         # Output name baseline
         out_name = fname_presuffix(
@@ -197,9 +197,9 @@ class BSplineApprox(SimpleInterface):
         data -= center
 
         # Calculate collocation matrix from (possibly resized) image and knot grids
-        colmat = sparse_vstack(
-            grid_bspline_weights(fmapnii, grid) for grid in bs_grids
-        ).T.tocsr()
+        colmat = sparse_hstack(
+            [grid_bspline_weights(fmapnii, grid) for grid in bs_grids]
+        ).tocsr()
 
         bs_grids_str = ["x".join(str(s) for s in grid.shape) for grid in bs_grids]
         bs_grids_str[-1] = f"and {bs_grids_str[-1]}"
@@ -254,9 +254,9 @@ class BSplineApprox(SimpleInterface):
                 mask = np.asanyarray(masknii.dataobj) > 1e-4
             else:
                 mask = np.ones_like(fmapnii.dataobj, dtype=bool)
-            colmat = sparse_vstack(
-                grid_bspline_weights(fmapnii, grid) for grid in bs_grids
-            ).T.tocsr()
+            colmat = sparse_hstack(
+                [grid_bspline_weights(fmapnii, grid) for grid in bs_grids]
+            ).tocsr()
 
         regressors = colmat[mask.reshape(-1), :]
         interp_data = np.zeros_like(data)

--- a/sdcflows/tests/test_transform.py
+++ b/sdcflows/tests/test_transform.py
@@ -348,16 +348,7 @@ def test_grid_bspline_weights():
         nb.Nifti1Image(np.zeros(target_shape), target_aff),
         nb.Nifti1Image(np.zeros(ctrl_shape), ctrl_aff),
     ).tocsr()
-    assert weights.shape == (np.prod(np.array(ctrl_shape) + 2), np.prod(target_shape))
-
-    # Calculate the legacy mask to index the weights below
-    legacy_mask = np.pad(
-        np.ones(ctrl_shape, dtype=bool),
-        ((1, 1), (1, 1), (1, 1)),
-    ).reshape(-1)
-
-    # Drop scipy's padding
-    weights = weights[legacy_mask]
+    assert weights.shape == (64, 1000)
     # Empirically determined numbers intended to indicate that something
     # significant has changed. If it turns out we've been doing this wrong,
     # these numbers will probably change.

--- a/sdcflows/tests/test_transform.py
+++ b/sdcflows/tests/test_transform.py
@@ -348,7 +348,16 @@ def test_grid_bspline_weights():
         nb.Nifti1Image(np.zeros(target_shape), target_aff),
         nb.Nifti1Image(np.zeros(ctrl_shape), ctrl_aff),
     ).tocsr()
-    assert weights.shape == (64, 1000)
+    assert weights.shape == (np.prod(np.array(ctrl_shape) + 2), np.prod(target_shape))
+
+    # Calculate the legacy mask to index the weights below
+    legacy_mask = np.pad(
+        np.ones(ctrl_shape, dtype=bool),
+        ((1, 1), (1, 1), (1, 1)),
+    ).reshape(-1)
+
+    # Drop scipy's padding
+    weights = weights[legacy_mask]
     # Empirically determined numbers intended to indicate that something
     # significant has changed. If it turns out we've been doing this wrong,
     # these numbers will probably change.

--- a/sdcflows/tests/test_transform.py
+++ b/sdcflows/tests/test_transform.py
@@ -348,11 +348,11 @@ def test_grid_bspline_weights():
         nb.Nifti1Image(np.zeros(target_shape), target_aff),
         nb.Nifti1Image(np.zeros(ctrl_shape), ctrl_aff),
     ).tocsr()
-    assert weights.shape == (64, 1000)
+    assert weights.shape == (1000, 64)
     # Empirically determined numbers intended to indicate that something
     # significant has changed. If it turns out we've been doing this wrong,
     # these numbers will probably change.
     assert np.isclose(weights[0, 0], 0.00089725334)
     assert np.isclose(weights[-1, -1], 0.18919244)
-    assert np.isclose(weights.sum(axis=1).max(), 129.3907)
-    assert np.isclose(weights.sum(axis=1).min(), 0.0052327816)
+    assert np.isclose(weights.sum(axis=0).max(), 129.3907)
+    assert np.isclose(weights.sum(axis=0).min(), 0.0052327816)

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -56,8 +56,8 @@ import attr
 import numpy as np
 from warnings import warn
 from scipy import ndimage as ndi
-from scipy.signal import cubic
-from scipy.sparse import vstack as sparse_vstack, kron, lil_array
+from scipy.interpolate import BSpline
+from scipy.sparse import vstack as sparse_vstack, kron
 
 import nibabel as nb
 import nitransforms as nt
@@ -325,7 +325,12 @@ class B0FieldTransform:
         for level in coeffs:
             wmat = grid_bspline_weights(target_reference, level)
             weights.append(wmat)
-            coeffs_data.append(level.get_fdata(dtype="float32").reshape(-1))
+
+            # Coefficients must be zero-padded because Scipy's BSpline pads the knots.
+            coeffs_data.append(np.pad(
+                level.get_fdata(dtype="float32"),
+                ((1, 1), (1, 1), (1, 1)),
+            ).reshape(-1))
 
         # Reconstruct the fieldmap (in Hz) from coefficients
         fmap = np.zeros(projected_reference.shape[:3], dtype="float32")
@@ -732,18 +737,16 @@ def grid_bspline_weights(target_nii, ctrl_nii, dtype="float32"):
         coords[axis] = np.arange(sample_shape[axis], dtype=dtype)
 
         # Calculate the index component of samples w.r.t. B-Spline knots along current axis
+        # Size of locations is L
         locs = nb.affines.apply_affine(target_to_grid, coords.T)[:, axis]
-        knots = np.arange(knots_shape[axis], dtype=dtype)
 
-        distance = np.abs(locs[np.newaxis, ...] - knots[..., np.newaxis])
-        within_support = distance < 2.0
-        d_vals, d_idxs = np.unique(distance[within_support], return_inverse=True)
-        bs_w = cubic(d_vals)
+        # Size of knots is K + 6 so that all locations are fully covered by basis
+        knots = np.arange(-3, knots_shape[axis] + 3, dtype=dtype)
 
-        colloc_ax = lil_array((knots_shape[axis], sample_shape[axis]), dtype=dtype)
-        colloc_ax[within_support] = bs_w[d_idxs]
-
-        wd.append(colloc_ax)
+        # Our original design matrices had size (K, L)
+        # However, BSpline.design_matrix() generates a size of (L, K + 2),
+        # hence the trasposition (and zero-padding of 1 at every face when using these)
+        wd.append(BSpline.design_matrix(locs, knots, 3).T)
 
     # Calculate the tensor product of the three design matrices
     return kron(kron(wd[0], wd[1]), wd[2]).astype(dtype)

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -745,7 +745,7 @@ def grid_bspline_weights(target_nii, ctrl_nii, dtype="float32"):
 
         # Our original design matrices had size (K, L)
         # However, BSpline.design_matrix() generates a size of (L, K + 2),
-        # hence the trasposition (and zero-padding of 1 at every face when using these)
+        # hence the transposition (and zero-padding of 1 at every face when using these)
         wd.append(BSpline.design_matrix(locs, knots, 3).T)
 
     # Calculate the tensor product of the three design matrices

--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -321,7 +321,7 @@ class B0FieldTransform:
 
         # Generate tensor-product B-Spline weights
         colmat = sparse_hstack(
-            [grid_bspline_weights(target_reference, level) for level in coeffs]
+            [grid_bspline_weights(projected_reference, level) for level in coeffs]
         ).tocsr()
         coefficients = np.hstack(
             [level.get_fdata(dtype="float32").reshape(-1) for level in coeffs]


### PR DESCRIPTION
This builds on and replaces #388. The additional padding broke our ability to reconstruct the field, as we were estimating more parameters but not actually saving them.

This PR maintains the current functionality and paves the way for implementing the Jacobian (#391) by using `BSpline()` objects directly instead of through `BSpline.design_matrix()`. I also restore the use of a `within_support` mask, which significantly decreases the runtime of `unwarp_wf.resample` nodes. There is little effect on `bs_filter` nodes, as we downsample to a low enough resolution to make the fit process very quick already.