### PR TITLE
FIX: Interpolate to floating point values

### DIFF
--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -523,7 +523,7 @@ class B0FieldTransform:
                 self.mapped.get_fdata(dtype="float32"),  # fieldmap in Hz
                 pe_info,
                 xfms,
-                output_dtype=output_dtype,
+                output_dtype='float32',
                 order=order,
                 mode=mode,
                 cval=cval,


### PR DESCRIPTION
When given images with `int16` on-disk data types, this could cause problems. Even if we save to `int16`, the in-memory values need to remain float until it's time to apply scaling.