### PR TITLE
FIX: Mask fieldmap before fitting spline field

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -195,6 +195,7 @@ class BSplineApprox(SimpleInterface):
             center = np.mean(data[mask])
 
         data -= center
+        data[~mask] = 0
 
         # Calculate collocation matrix from (possibly resized) image and knot grids
         colmat = sparse_hstack(
@@ -214,7 +215,7 @@ class BSplineApprox(SimpleInterface):
             alpha=self.inputs.ridge_alpha, fit_intercept=False, solver="lsqr"
         )
         for attempt in range(3):
-            model.fit(colmat[mask.reshape(-1), :], data[mask])
+            model.fit(colmat, data.reshape(-1))
             extreme = np.abs(model.coef_).max()
             LOGGER.debug(f"Model fit attempt {attempt}: max(|coeffs|) = {extreme}")
             # Normal values seem to be ~1e2, bad ~1e8. May want to tweak this if


### PR DESCRIPTION
Previously, we fit a spline field to the within-mask portion of a fieldmap, which could lead to large peaks outside the mask. Applying the mask to the reconstructed field can produce discontinuities in resampling. Instead of attempting to attenuate the peaks outside the mask in a smooth way, we set the fit values outside the mask to zero, and let the spline fit find a smooth field.

Replaces #395.
Addresses nipreps/fmriprep#3013.


## Before

![Screenshot from 2023-09-26 07-48-16](https://github.com/nipreps/sdcflows/assets/83442/49209639-fdc5-4085-8ec7-634f3c775adc)


## After

![Screenshot from 2023-09-26 10-39-02](https://github.com/nipreps/sdcflows/assets/83442/5600e1ac-bd6d-4718-aafc-6f328c663192)
