### PR TITLE
ENH: Implement Jacobian weighting during unwarp [backport gh-391]

### DIFF
--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -197,7 +197,10 @@ class B0FieldTransform:
         # fmap * ro_time is the voxel-shift map (VSM)
         # The VSM is just the displacements field given in index coordinates
         # voxcoords is the deformation field, i.e., the target position of each voxel
-        voxcoords[pe_axis, ...] += fmap.reshape(-1) * ro_time
+        vsm = fmap * ro_time
+        voxcoords[pe_axis, ...] += vsm.reshape(-1)
+
+        jacobian = 1 + np.gradient(vsm, axis=pe_axis)
 
         # Prepare data
         data = np.squeeze(np.asanyarray(spatialimage.dataobj))
@@ -212,7 +215,7 @@ class B0FieldTransform:
             mode=mode,
             cval=cval,
             prefilter=prefilter,
-        ).reshape(spatialimage.shape)
+        ).reshape(spatialimage.shape) * jacobian
 
         moved = spatialimage.__class__(
             resampled, spatialimage.affine, spatialimage.header


### PR DESCRIPTION
Slightly different shaping than in the latest `master`, but I believe this is the equivalent. It would be good to get a test. @themeo would you be able to test? If you're using `fmriprep-docker`, it's pretty easy:

```console
$ git clone https://github.com/effigies/sdcflows.git
$ git -C sdcflows checkout bp/2.5.x/391
$ pipx run "fmriprep-docker==23.1.4" [usual arguments] --patch sdcflows=$PWD/sdcflows/sdcflows
```

This will mount the sdcflows directory into the correct location to be picked up by fMRIPrep.