### PR TITLE
FIX: Mask fieldmap before fitting spline field [backport gh-396]

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -195,6 +195,7 @@ class BSplineApprox(SimpleInterface):
             center = np.mean(data[mask])
 
         data -= center
+        data[~mask] = 0
 
         # Calculate collocation matrix from (possibly resized) image and knot grids
         colmat = sparse_vstack(grid_bspline_weights(fmapnii, grid) for grid in bs_grids).T.tocsr()
@@ -210,7 +211,7 @@ class BSplineApprox(SimpleInterface):
         # Fit the model
         model = lm.Ridge(alpha=self.inputs.ridge_alpha, fit_intercept=False, solver='lsqr')
         for attempt in range(3):
-            model.fit(colmat[mask.reshape(-1), :], data[mask])
+            model.fit(colmat, data.reshape(-1))
             extreme = np.abs(model.coef_).max()
             LOGGER.debug(f"Model fit attempt {attempt}: max(|coeffs|) = {extreme}")
             # Normal values seem to be ~1e2, bad ~1e8. May want to tweak this if


### PR DESCRIPTION
Straightforward backport. Would still be good to get a test. To anybody willing:

```
$ git clone https://github.com/effigies/sdcflows.git
$ git -C sdcflows checkout bp/2.5.x/396
$ pipx run "fmriprep-docker==23.1.4" [usual arguments] --patch sdcflows=$PWD/sdcflows/sdcflows
```

Backport of #396.