### PR TITLE
DOC: Fix doc build for 2.5.x branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
           command: |
             python -m venv /tmp/venv
             source /tmp/venv/bin/activate
-            python -m pip install -U pip setuptools_scm
+            python -m pip install -U pip setuptools setuptools_scm
             pip install --no-cache-dir -r docs/requirements.txt
       - run:
           name: Build only this commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,8 +349,7 @@ jobs:
           flags: unittests
 
   build_docs:
-    docker:
-      - image: python:3.8.5
+    <<: *python_defaults
     working_directory: /tmp/gh-pages
     environment:
       - FSLOUTPUTTYPE: NIFTI
@@ -363,8 +362,8 @@ jobs:
       - run:
           name: Install Graphviz
           command: |
-            apt-get update -y
-            apt-get install -y --no-install-recommends graphviz
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends graphviz
       - run:
           name: Install deps
           command: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ numfig = True
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 attrs >= 20.1.0
-furo ~= 2021.10.09
+furo >= 2021.10.09
 matplotlib >= 2.2.0
 nibabel
 nipype >= 1.5.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ numpy
 packaging
 pydot >= 1.2.3
 pydotplus
-sphinx ~= 4.2
+sphinx >= 7.2.2
 sphinxcontrib-apidoc
 sphinxcontrib-napoleon
 templateflow

--- a/sdcflows/__init__.py
+++ b/sdcflows/__init__.py
@@ -9,6 +9,6 @@ except ModuleNotFoundError:
     try:
         __version__ = get_distribution(__packagename__).version
     except DistributionNotFound:
-        __version__ = "unknown"
+        __version__ = "0+unknown"
     del get_distribution
     del DistributionNotFound


### PR DESCRIPTION
Backports #390, and also attempts to pacify the following error from the build:

```
ERROR: setuptools==47.1.0 is used in combination with setuptools_scm>=8.x

Your build configuration is incomplete and previously worked by accident!
setuptools_scm requires setuptools>=61

Suggested workaround if applicable:
 - migrating from the deprecated setup_requires mechanism to pep517/518
   and using a pyproject.toml to declare build dependencies
   which are reliably pre-installed before running the build tools
```