### PR TITLE
FIX: Drop header before resampling image to avoid unsafe cast

### DIFF
--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -137,7 +137,12 @@ class UniformGrid(SimpleInterface):
                     nii.__class__(nii.dataobj, refaff, nii.header).to_filename(retval[i])
                 continue
 
-            resampler.apply(nii).to_filename(retval[i])
+            # Hack around nitransforms' unsafe cast by dropping get_data_dtype that conflicts
+            # with effective dtype
+            # NT23_0_1: Isssue in nitransforms.base.TransformBase.apply
+            regridded_img = resampler.apply(nii.__class__(np.asanyarray(nii.dataobj), nii.affine))
+            # Restore the original on-disk data type
+            nii.__class__(regridded_img.dataobj, refaff, nii.header).to_filename(retval[i])
 
         self._results["out_data"] = retval
 


### PR DESCRIPTION
int16 images with scale factors can get badly truncated or wrapped. This PR scales the data array and drops the header before passing to `Affine().resample()` to avoid this. We then re-add the dtype, though this may not be necessary. I think the effects of multiple interpolation are going to be minimal here, so keeping dtypes as expected is probably worth it.