### PR TITLE
[FIX] Change `os.basename` to `os.path.basename`

### DIFF
--- a/sdcflows/interfaces/fmap.py
+++ b/sdcflows/interfaces/fmap.py
@@ -362,7 +362,7 @@ def _conform_img(
     if np.allclose(img.affine, target_img.affine):
         return img.get_filename()
 
-    basename = os.basename(img.get_filename())
+    basename = os.path.basename(img.get_filename())
     out_file = os.path.join(cwd, basename)
 
     LOGGER.info(f"Copying affine to {basename}")


### PR DESCRIPTION
Addresses bug found in https://neurostars.org/t/attributeerror-module-os-has-no-attribute-basename/27604/2.

An instance of `os.basename` is leading to errors since it should be `os.path.basename`.