### PR TITLE
FIX: Derive field from SyN displacements using EPI affine

### DIFF
--- a/sdcflows/interfaces/fmap.py
+++ b/sdcflows/interfaces/fmap.py
@@ -161,6 +161,7 @@ class CheckB0Units(SimpleInterface):
 
 class _DisplacementsField2FieldmapInputSpec(BaseInterfaceInputSpec):
     transform = File(exists=True, mandatory=True, desc="input displacements field")
+    epi = File(exists=True, mandatory=True, desc="source EPI image")
     ro_time = traits.Float(mandatory=True, desc="total readout time")
     pe_dir = traits.Enum(
         "j-", "j", "i", "i-", "k", "k-", mandatory=True, desc="phase encoding direction"
@@ -189,6 +190,7 @@ class DisplacementsField2Fieldmap(SimpleInterface):
         )
         fmapnii = disp_to_fmap(
             nb.load(self.inputs.transform),
+            nb.load(self.inputs.epi),
             ro_time=self.inputs.ro_time,
             pe_dir=self.inputs.pe_dir,
             itk_format=self.inputs.itk_transform,

--- a/sdcflows/tests/test_transform.py
+++ b/sdcflows/tests/test_transform.py
@@ -327,11 +327,11 @@ def test_conversions(tmpdir, testdata_dir, pe_dir):
             ro_time=0.2,
             pe_dir=pe_dir,
         ),
+        fmap_nii,
         ro_time=0.2,
         pe_dir=pe_dir,
     )
 
-    new_nii.to_filename("test.nii.gz")
     assert np.allclose(
         fmap_nii.get_fdata(dtype="float32"),
         new_nii.get_fdata(dtype="float32"),

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -267,14 +267,15 @@ template [@fieldmapless3].
     )
 
     # Regularize with B-Splines
-    bs_filter = pe.Node(BSplineApprox(), name="bs_filter")
+    bs_filter = pe.Node(
+        BSplineApprox(recenter=False, debug=debug, extrapolate=not debug),
+        name="bs_filter",
+    )
     bs_filter.interface._always_run = debug
     bs_filter.inputs.bs_spacing = (
         [DEFAULT_LF_ZOOMS_MM, DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]
     )
-    bs_filter.inputs.extrapolate = not debug
 
-    # fmt: off
     workflow.connect([
         (inputnode, readout_time, [(("epi_ref", _pop), "in_file"),
                                    (("epi_ref", _pull), "metadata")]),
@@ -330,8 +331,7 @@ template [@fieldmapless3].
         (bs_filter, outputnode, [("out_coeff", "fmap_coeff")]),
         (unwarp, outputnode, [("out_corrected", "fmap_ref"),
                               ("out_field", "fmap")]),
-    ])
-    # fmt: on
+    ])  # fmt:skip
 
     return workflow
 

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -247,7 +247,7 @@ template [@fieldmapless3].
 
     # Extract the corresponding fieldmap in Hz
     extract_field = pe.Node(
-        DisplacementsField2Fieldmap(demean=True), name="extract_field"
+        DisplacementsField2Fieldmap(), name="extract_field"
     )
 
     unwarp = pe.Node(ApplyCoeffsField(), name="unwarp")
@@ -314,6 +314,7 @@ template [@fieldmapless3].
         (epi_merge, syn, [("out", "moving_image")]),
         (moving_masks, syn, [("out", "moving_image_masks")]),
         (syn, extract_field, [(("forward_transforms", _pop), "transform")]),
+        (clip_epi, extract_field, [("out_file", "epi")]),
         (readout_time, extract_field, [("readout_time", "ro_time"),
                                        ("pe_direction", "pe_dir")]),
         (extract_field, zooms_field, [("out_file", "input_image")]),


### PR DESCRIPTION
Theoretically, a fieldmap in Hz is the number of voxels/second that signal is shifted from the true location. SyN-SDC calculates the shift in mm from the true location. In order to find the equivalent fieldmap, we need the size of the voxels, readout time and phase-encoding direction of the EPI image that is to be corrected.

Previously, we were deriving the fieldmap from the readout time and phase-encoding direction of the EPI image, but the voxel size of the displacement field. This causes an overestimate of the number of voxels to be shifted, and thus exaggerated correction.

Original EPI:

![image](https://github.com/nipreps/sdcflows/assets/83442/5da366ea-3217-44af-83cf-db9aab1169a3)

Current unwarp: 

![image](https://github.com/nipreps/sdcflows/assets/83442/0f71da74-c988-4801-8b4f-9e98f0ad23c5)

New unwarp:

![image](https://github.com/nipreps/sdcflows/assets/83442/8e975d0c-c569-4424-89df-606e9ca9a18a)