### PR TITLE
FIX: Enable fieldmapless by default in CLI

### DIFF
--- a/sdcflows/cli/main.py
+++ b/sdcflows/cli/main.py
@@ -139,6 +139,12 @@ def main(argv=None):
     if exitcode != 0:
         sys.exit(exitcode)
 
+    if len(sdcflows_wf.list_node_names()) == 0:
+        config.loggers.cli.critical(
+            'Workflow did not generate any jobs. Please check your inputs are valid.'
+        )
+        sys.exit(os.EX_USAGE)
+
     # Initialize nipype config
     config.nipype.init()
     # Make sure loggers are started

--- a/sdcflows/cli/parser.py
+++ b/sdcflows/cli/parser.py
@@ -248,8 +248,8 @@ not be what you want in, e.g., shared systems like a HPC cluster.""",
     g_outputs.add_argument(
         "--no-fmapless",
         action="store_false",
-        dest="fieldmapless",
-        default=False,
+        dest="fmapless",
+        default=True,
         help="Allow fieldmap-less estimation",
     )
     g_outputs.add_argument(


### PR DESCRIPTION
As currently written, SyN-SDC cannot run, since we store `False` by default, and only allow `False` to be set with `--no-fmapless`. Also, we were using the wrong variable; elsewhere we use `fmapless`, not `fieldmapless`.

While here, I'm adding a check that the constructed workflow is not empty and giving a separate error message.