### PR TITLE
FIX: Documentation was not building because of warnings issued from nbsphinx's output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ jobs:
           name: Install Graphviz & pandoc
           command: |
             sudo apt-get update -y
-            sudo apt-get install -y --no-install-recommends graphviz pandoc
+            sudo apt-get install -y --no-install-recommends graphviz pandoc texlive
       - run:
           name: Install deps
           command: |
@@ -384,7 +384,7 @@ jobs:
             source /tmp/venv/bin/activate
             python -m hatch version | tail -n1 | xargs
             BRANCH=$( echo $CIRCLE_BRANCH | sed 's+/+_+g' )
-            make -C docs SPHINXOPTS="-W" BUILDDIR="$HOME/docs" OUTDIR=${CIRCLE_TAG:-$BRANCH} html
+            make -C docs SPHINXOPTS="-W -v" BUILDDIR="$HOME/docs" OUTDIR=${CIRCLE_TAG:-$BRANCH} html
       - store_artifacts:
           path: ~/docs/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,7 @@ jobs:
             source /tmp/venv/bin/activate
             python -m hatch version | tail -n1 | xargs
             BRANCH=$( echo $CIRCLE_BRANCH | sed 's+/+_+g' )
+            python -c "from templateflow.api import get; get('MNI152NLin2009cAsym', desc='brain', resolution=1, suffix='T1w')"
             make -C docs SPHINXOPTS="-W -v" BUILDDIR="$HOME/docs" OUTDIR=${CIRCLE_TAG:-$BRANCH} html
       - store_artifacts:
           path: ~/docs/

--- a/docs/notebooks/SDC - Theory and physics.ipynb
+++ b/docs/notebooks/SDC - Theory and physics.ipynb
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = np.asanyarray(nb.load(get(\"MNI152NLin2009cAsym\", desc=\"brain\", resolution=1, suffix=\"T1w\")).dataobj)"
+    "data = np.asanyarray(nb.load(get(\"MNI152NLin2009cAsym\", desc=\"brain\", resolution=1, suffix=\"T1w\")).dataobj);"
    ]
   },
   {


### PR DESCRIPTION
The new notebook has some latex insets, and I believe pandoc is generating empty environments for them, which translate into warnings assumed as errors.

It is the only difference I could think of between the environment in CircleCI and the testing environment I've created on my workstation.

EDIT: the problem was the conversion of the output of the cell that pulls one template from templateflow. Indeed, a raw directive is issued but I think the output is not correctly formatted in the intermediate RST.

This PR downloads the necessary template before running the notebook.

Resolves: #414.