### PR TITLE
FIX: Remove unused ANTs parameter that was removed in 2.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,3 @@
-docs_deploy: &docs
-  docker:
-    - image: node:8.10.0
-  working_directory: /tmp/gh-pages
-  steps:
-    - run:
-        name: Check whether this is the original repo
-        command: |
-          if [[ "$CIRCLE_PROJECT_USERNAME" != "nipreps" ]]; then
-              echo "Not in nipreps/sdcflows - skipping docs deploy."
-              circleci step halt
-          fi
-    - add_ssh_keys:
-        fingerprints:
-          - "46:48:1e:6d:00:0e:f2:f8:e5:aa:b9:aa:da:eb:59:4e"
-    - run:
-        name: Install gh-pages tool
-        command: |
-          npm install -g --silent gh-pages@2.0.1
-    - checkout
-    - run:
-        name: Set git settings
-        command: |
-          git config user.email "nipreps@gmail.com"
-          git config user.name "Documentation Push"
-    - attach_workspace:
-        at: docs/_build
-    - run:
-        name: Disable jekyll builds
-        command: touch docs/_build/html/.nojekyll
-    - run:
-        name: Deploy docs to gh-pages branch
-        command: gh-pages --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
-
 version: 2.1
 orbs:
   docker: circleci/docker@1.6.0
@@ -301,70 +267,6 @@ jobs:
       - store_test_results:
           path: /tmp/tests
 
-  build_docs:
-    docker:
-      - image: cimg/python:3.9.16
-    working_directory: /tmp/gh-pages
-    environment:
-      - FSLOUTPUTTYPE: NIFTI
-      - SUBJECTS_DIR: /tmp/subjects
-    steps:
-      - checkout
-      - run:
-          name: Create subjects folder
-          command: mkdir -p $SUBJECTS_DIR
-      - run:
-          name: Install Graphviz
-          command: sudo apt-get update && sudo apt-get -y install --no-install-recommends graphviz
-      - run:
-          name: Install deps
-          command: |
-            pip install --no-cache-dir -r docs/requirements.txt
-            pip install --no-cache-dir "setuptools_scm[toml]"
-            python -m setuptools_scm
-      - run:
-          name: Build only this commit
-          command: make -C docs SPHINXOPTS="-W" BUILDDIR="$HOME/docs" OUTDIR=no_version_html html
-      - store_artifacts:
-          path: /home/circleci/docs/no_version_html
-          destination: noversion
-      - run:
-          name: Stop or generate versioned docs?
-          command: |
-            set +e
-            force_versioned="$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[docs?[ _]?versions?\]' )"
-            set -e
-            if [[ "x${CIRCLE_TAG}" = "x" && "${CIRCLE_BRANCH}" != "master" && "x${force_versioned}" = "x" ]]; then
-              echo "Not a tag or master branch - skipping versioned docs."
-              circleci step halt
-            fi
-      - run:
-          name: Clean-up nonversioned docs.
-          command: make -C docs clean
-      - restore_cache:
-          keys:
-            - docs-v2-{{ .Branch }}-{{ .Revision }}
-            - docs-v2-{{ .Branch }}-
-            - docs-v2-maint/1.3.x
-            - docs-v2-
-          paths:
-            - ./docs/_build
-      - run:
-          name: Generate Versioned Docs
-          command: |
-            BRANCH=$( echo $CIRCLE_BRANCH | sed 's+/+_+g' )
-            make -C docs SPHINXOPTS="-W" BUILDDIR="$HOME/docs" OUTDIR=${CIRCLE_TAG:-$BRANCH} html
-      - save_cache:
-          key: docs-v2-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - ./docs/_build
-      - persist_to_workspace:
-          root: docs/_build
-          paths: html
-      - store_artifacts:
-          path: ./docs/_build/html/html
-          destination: versioned
-
   deploy_docker:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -460,9 +362,6 @@ jobs:
             python3 -m twine check dist/*
             python3 -m twine upload dist/* --non-interactive
 
-  deploy_docs_tag:
-    <<: *docs
-
 workflows:
   version: 2
   build_deploy:
@@ -503,7 +402,6 @@ workflows:
           context:
             - nipreps-common
           requires:
-            - build_docs
             - test_package
             - build_n_pytest
           filters:
@@ -517,23 +415,6 @@ workflows:
             - nipreps-common
           requires:
             - deploy_pypi
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-
-      - build_docs:
-          filters:
-            branches:
-              ignore:
-                - /tests?\/.*/
-            tags:
-              only: /.*/
-
-      - deploy_docs_tag:
-          requires:
-            - deploy_docker
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,12 +178,17 @@ jobs:
                 docker tag localhost:5000/sdcflows nipreps/sdcflows
             else
                 LATEST=$( git describe --abbrev=0 )
-                echo "Pulling nipreps/sdcflows:$LATEST from Docker Hub"
                 docker pull ubuntu:xenial-20191010
                 docker tag ubuntu:xenial-20191010 localhost:5000/ubuntu
                 docker push localhost:5000/ubuntu
-                docker pull nipreps/sdcflows:$LATEST
-                docker tag nipreps/sdcflows:$LATEST nipreps/sdcflows:latest
+                if docker pull nipreps/sdcflows:$LATEST; then
+                    echo "Pulling nipreps/sdcflows:$LATEST from Docker Hub"
+                    docker tag nipreps/sdcflows:$LATEST nipreps/sdcflows:latest
+                else
+                    echo "Falling back to nipreps/sdcflows:1.3.3"
+                    docker pull nipreps/sdcflows:1.3.3
+                    docker tag nipreps/sdcflows:1.3.3 nipreps/sdcflows:latest
+                fi
             fi
       - run:
           name: Build Docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - freesurfer-v1-{{ .BuildNum }}
-            - freesurfer-v1-
+            - freesurfer-v0-{{ .BuildNum }}
+            - freesurfer-v0-
       - run:
           name: Pull FreeSurfer down
           command: |
@@ -243,8 +243,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - freesurfer-v1-{{ .BuildNum }}
-            - freesurfer-v1-
+            - freesurfer-v0-{{ .BuildNum }}
+            - freesurfer-v0-
       - restore_cache:
           keys:
             - data-v2-{{ .Branch }}-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,14 +131,13 @@ jobs:
                    --exclude='freesurfer/subjects/sample-*.mgz' \
                    --exclude='freesurfer/subjects/V1_average' \
                    --exclude='freesurfer/trctrain'
-              pushd /tmp/freesurfer
-              echo "${FS_LICENSE_CONTENT}" | base64 -d | sh
+              echo "b2VzdGViYW5Ac3RhbmZvcmQuZWR1CjMwNzU2CiAqQ1MzYkJ5VXMxdTVNCiBGU2kvUGJsejJxR1V3Cg==" | base64 -d > /tmp/freesurfer/license.txt
             else
               echo "FreeSurfer was cached."
               circleci step halt
             fi
       - save_cache:
-          key: freesurfer-v1-{{ .BuildNum }}
+          key: freesurfer-v0-{{ .BuildNum }}
           paths:
             - /tmp/freesurfer
 

--- a/sdcflows/data/affine.json
+++ b/sdcflows/data/affine.json
@@ -6,7 +6,6 @@
     "winsorize_upper_quantile": 0.995,
     "collapse_output_transforms": true,
     "use_histogram_matching": [ false, false ],
-    "use_estimate_learning_rate_once": [ false, false ],
     "transforms": [ "Rigid", "Affine" ],
     "number_of_iterations": [ [ 1000, 500, 250, 100 ], [ 1000, 500, 250, 100 ] ],
     "transform_parameters": [ [ 0.1 ], [ 0.1 ] ],

--- a/sdcflows/data/fmap-any_registration.json
+++ b/sdcflows/data/fmap-any_registration.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Translation", "Affine" ],
     "number_of_iterations": [ [ 500 ], [ 200 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],

--- a/sdcflows/data/fmap-any_registration_testing.json
+++ b/sdcflows/data/fmap-any_registration_testing.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Rigid", "Rigid" ],
     "number_of_iterations": [ [ 500 ], [ 100 ] ],
     "transform_parameters": [ [ 1.0 ], [ 0.5 ] ],

--- a/sdcflows/data/susceptibility_syn.json
+++ b/sdcflows/data/susceptibility_syn.json
@@ -14,7 +14,6 @@
     "shrink_factors": [ [ 2, 1 ], [ 1, 1 ] ],
     "winsorize_upper_quantile": 1.0,
     "winsorize_lower_quantile": 0.001,
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/sdcflows/data/translation_rigid.json
+++ b/sdcflows/data/translation_rigid.json
@@ -6,7 +6,6 @@
     "collapse_output_transforms": true,
     "write_composite_transform": true,
     "use_histogram_matching": [ true, true ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "transforms": [ "Translation", "Rigid" ],
     "number_of_iterations": [ [ 500 ], [ 200 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],


### PR DESCRIPTION
Hello! :)

Starting with ANTS 2.4.1 there is a flag that has disappeared in the AntsRegistration command and we would like to backport the commit that fixes it  ( [link](https://github.com/nipreps/sdcflows/commit/24662aa51bbe8e11de7be47be94e99e46dbd26ba) ) into this version of sdcworkflows, since Halfpipe depends on it and we want to bump ANTS to solve problems with the FixN4BiasFieldCorrection interface that are fixed in the latest version.

