### PR TITLE
test(deps): Test against scipy 1.12

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -10,7 +10,7 @@ dependencies:
   - mkl-service=2.4
   # Base scientific python stack; required by FSL, so pinned here
   - numpy=1.26
-  - scipy=1.11
+  - scipy=1.12
   - matplotlib=3.8
   - pandas=2.1
   - h5py=3.8


### PR DESCRIPTION
Seeing a bug when attempting to update fMRIPrep environment to include scipy 1.12:

```python
	Traceback (most recent call last):
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/nipype/interfaces/base/core.py", line 397, in run
	    runtime = self._run_interface(runtime)
	              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/interfaces/bspline.py", line 413, in _run_interface
	    unwarp.apply(
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/transform.py", line 524, in apply
	    resampled = asyncio.run(
	                ^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/asyncio/runners.py", line 190, in run
	    return runner.run(main)
	           ^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/asyncio/runners.py", line 118, in run
	    return self._loop.run_until_complete(task)
	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
	    return future.result()
	           ^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/transform.py", line 230, in unwarp_parallel
	    await asyncio.gather(*tasks)
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/transform.py", line 129, in worker
	    result = await loop.run_in_executor(
	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/concurrent/futures/thread.py", line 58, in run
	    result = self.fn(*self.args, **self.kwargs)
	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/transform.py", line 105, in _sdc_unwarp
	    resampled = ndi.map_coordinates(
	                ^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/scipy/ndimage/_interpolation.py", line 455, in map_coordinates
	    output = _ni_support._get_output(output, input, shape=output_shape,
	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/scipy/ndimage/_ni_support.py", line 96, in _get_output
	    output = f_dict[output]
	             ~~~~~~^^^^^^^^
	KeyError: 'float32'
```

This will need to be resolved here.