### PR TITLE
Remove non-alphanumeric characters from workflow names and output entities

### DIFF
--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -446,7 +446,8 @@ class FieldmapEstimation:
             return self._wf
 
         # Override workflow name
-        kwargs["name"] = f"wf_{self.bids_id}"
+        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', self.bids_id)
+        kwargs["name"] = f"wf_{clean_bids_id}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf

--- a/sdcflows/workflows/fit/base.py
+++ b/sdcflows/workflows/fit/base.py
@@ -25,6 +25,8 @@
 
 def init_sdcflows_wf():
     """Create a multi-subject, multi-estimator *SDCFlows* workflow."""
+    import re
+
     from nipype.pipeline.engine import Workflow
     from niworkflows.utils.bids import collect_participants
 
@@ -51,6 +53,8 @@ def init_sdcflows_wf():
 
     for subject, sub_estimators in estimators_record.items():
         for estim in sub_estimators:
+            clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estim.bids_id)
+
             estim_wf = estim.get_workflow(
                 omp_nthreads=config.nipype.omp_nthreads,
                 sloppy=False,
@@ -61,7 +65,7 @@ def init_sdcflows_wf():
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
                 write_coeff=True,
-                name=f"fmap_derivatives_{estim.bids_id}",
+                name=f"fmap_derivatives_{clean_bids_id}",
             )
 
             source_paths = [
@@ -76,7 +80,7 @@ def init_sdcflows_wf():
                 fmap_type=estim.method,
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
-                name=f"fmap_reports_{estim.bids_id}",
+                name=f"fmap_reports_{clean_bids_id}",
             )
             reportlets_wf.inputs.inputnode.source_files = source_paths
 

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -21,6 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Writing out outputs."""
+import re
+
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from niworkflows.interfaces.bids import DerivativesDataSink as _DDS
@@ -156,7 +158,7 @@ def init_fmap_derivatives_wf(
     """
     custom_entities = custom_entities or {}
     if bids_fmap_id:
-        custom_entities["fmapid"] = bids_fmap_id.replace("_", "")
+        custom_entities["fmapid"] = re.sub(r'[^a-zA-Z0-9]', '', bids_fmap_id)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -79,7 +79,7 @@ def init_fmap_reports_wf(
 
     custom_entities = custom_entities or {}
     if bids_fmap_id:
-        custom_entities["fmapid"] = bids_fmap_id.replace("_", "")
+        custom_entities["fmapid"] = re.sub(r'[^a-zA-Z0-9]', '', bids_fmap_id)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -23,7 +23,10 @@
 """Test the base workflow."""
 from pathlib import Path
 import os
+import re
+
 import pytest
+
 from sdcflows import fieldmaps as fm
 from sdcflows.utils.wrangler import find_estimators
 from sdcflows.workflows.base import init_fmap_preproc_wf
@@ -55,7 +58,8 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
         if estimator.method != fm.EstimatorType.PEPOLAR:
             continue
 
-        inputnode = wf.get_node(f"in_{estimator.bids_id}")
+        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estimator.bids_id)
+        inputnode = wf.get_node(f"in_{clean_bids_id}")
         inputnode.inputs.in_data = [str(f.path) for f in estimator.sources]
         inputnode.inputs.metadata = [f.metadata for f in estimator.sources]
 


### PR DESCRIPTION
Closes #295.

Changes proposed:

- Use regular expressions to remove non-alphanumeric characters from the B0FieldIdentifier used in workflow names and output entities.