### PR TITLE
FIX: Update suffix only when finding related fieldmap files

### DIFF
--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -340,9 +340,9 @@ class FieldmapEstimation:
                 try:
                     new_path = (
                         sources[0].parent / sources[0].name
-                        .replace("fieldmap", "magnitude")
-                        .replace("diff", "1")
-                        .replace("phase", "magnitude")
+                        .replace("_fieldmap", "_magnitude")
+                        .replace("_phasediff", "_phase1")
+                        .replace("_phase", "_magnitude")
                     )
                     self.sources.append(FieldmapFile(new_path))
                 except Exception:


### PR DESCRIPTION
SDCflows wants to replace the suffix but also accidentally replaces substrings elsewhere in the filename (e.g. in files named `sub-01-acq-fieldmap_magnitude1.nii.gz`). This PR fixes that -- see also github issue #264