### PR TITLE
Replace non-word/special characters from B0FieldIdentifier/Source tags

### DIFF
--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -446,8 +446,8 @@ class FieldmapEstimation:
             return self._wf
 
         # Override workflow name (non-word/special characters are replaced to avoid nipype invalid node name errors)
-        bids_id = re.sub(r'[^-\w]', '-', self.bids_id)
-        kwargs["name"] = f"wf_{bids_id}"
+        bids_id_clean = re.sub(r'[^-\w]', '-', self.bids_id)
+        kwargs["name"] = f"wf_{bids_id_clean}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf

--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -445,8 +445,8 @@ class FieldmapEstimation:
         if self._wf is not None:
             return self._wf
 
-        # Override workflow name
-        kwargs["name"] = f"wf_{self.bids_id}"
+        # Override workflow name (non-word/special characters are replaced to avoid nipype invalid node name errors)
+        kwargs["name"] = f"wf_{re.sub(r'[^-\w]', '-', self.bids_id)}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf

--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -446,7 +446,8 @@ class FieldmapEstimation:
             return self._wf
 
         # Override workflow name (non-word/special characters are replaced to avoid nipype invalid node name errors)
-        kwargs["name"] = f"wf_{re.sub(r'[^-\w]', '-', self.bids_id)}"
+        bids_id = re.sub(r'[^-\w]', '-', self.bids_id)
+        kwargs["name"] = f"wf_{bids_id}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf


### PR DESCRIPTION
Using e.g. `<<sesmri02>>` as a `B0FieldIdentifier` (which is a perfectly valid thing to do) leads to a nipype invalid node name error:

![image](https://github.com/nipreps/sdcflows/assets/15156015/fac8dd2a-42ac-46c0-a13e-eb22f9568eae)

This PR replaces the special characters, such as '<` and `>` with `-`