### PR TITLE
DOC: Un-mock the already-imported numpy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,6 @@ autodoc_mock_imports = [
     "nilearn",
     "nipy",
     "nitime",
-    "numpy",
     "pandas",
     "seaborn",
     "skimage",


### PR DESCRIPTION
Fixes #439. The issue is that we are importing `sdcflows`:

https://github.com/nipreps/sdcflows/blob/357ef3e683f05a1722c113b1dc94ceed2ed02a53/docs/conf.py#L10

This will load `numpy` and apparently create some references that will continue to expect numpy arrays. Or possibly our docstrings generate numpy arrays. But the mock will then make future dives into numpy fail, leading to conflict.

Removing the mock resolves the issue.