### PR TITLE
RF: Add sanitized_id field to FieldmapEstimation

### DIFF
--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -300,6 +300,9 @@ class FieldmapEstimation:
     bids_id = attr.ib(default=None, kw_only=True, type=str, on_setattr=_id_setter)
     """The unique ``B0FieldIdentifier`` field of this fieldmap."""
 
+    sanitized_id = attr.ib(init=False, repr=False)
+    """Sanitized version of the bids_id with special characters replaced by underscores."""
+
     _wf = attr.ib(init=False, default=None, repr=False)
     """Internal pointer to a workflow."""
 
@@ -436,6 +439,10 @@ class FieldmapEstimation:
         for intent_file in intents_meta:
             _intents[intent_file].add(self.bids_id)
 
+        # Provide a sanitized identifier that can be used in cases where
+        # special characters are not allowed.
+        self.sanitized_id = re.sub(r'[^a-zA-Z0-9]', '_', self.bids_id)
+
     def paths(self):
         """Return a tuple of paths that are sorted."""
         return tuple(sorted(str(f.path) for f in self.sources))
@@ -446,8 +453,7 @@ class FieldmapEstimation:
             return self._wf
 
         # Override workflow name
-        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', self.bids_id)
-        kwargs["name"] = f"wf_{clean_bids_id}"
+        kwargs["name"] = f"wf_{self.sanitized_id}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf

--- a/sdcflows/fieldmaps.py
+++ b/sdcflows/fieldmaps.py
@@ -446,7 +446,8 @@ class FieldmapEstimation:
             return self._wf
 
         # Override workflow name
-        kwargs["name"] = f"wf_{self.bids_id}"
+        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', self.bids_id)
+        kwargs["name"] = f"wf_{clean_bids_id}"
 
         if self.method in (EstimatorType.MAPPED, EstimatorType.PHASEDIFF):
             from .workflows.fit.fieldmap import init_fmap_wf

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -21,8 +21,6 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Estimate fieldmaps for :abbr:`SDC (susceptibility distortion correction)`."""
-import re
-
 from nipype import logging
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
@@ -108,7 +106,6 @@ def init_fmap_preproc_wf(
     )
 
     for n, estimator in enumerate(estimators, 1):
-        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estimator.bids_id)
         est_wf = estimator.get_workflow(
             omp_nthreads=omp_nthreads,
             debug=debug,
@@ -119,7 +116,7 @@ def init_fmap_preproc_wf(
         ]
 
         out_map = pe.Node(
-            niu.IdentityInterface(fields=out_fields), name=f"out_{clean_bids_id}"
+            niu.IdentityInterface(fields=out_fields), name=f"out_{estimator.bids_id}"
         )
         out_map.inputs.fmap_id = estimator.bids_id
 
@@ -127,7 +124,7 @@ def init_fmap_preproc_wf(
             output_dir=str(output_dir),
             write_coeff=True,
             bids_fmap_id=estimator.bids_id,
-            name=f"fmap_derivatives_wf_{clean_bids_id}",
+            name=f"fmap_derivatives_wf_{estimator.sanitized_id}",
         )
         fmap_derivatives_wf.inputs.inputnode.source_files = source_files
         fmap_derivatives_wf.inputs.inputnode.fmap_meta = [
@@ -138,7 +135,7 @@ def init_fmap_preproc_wf(
             output_dir=str(output_dir),
             fmap_type=str(estimator.method).rpartition(".")[-1].lower(),
             bids_fmap_id=estimator.bids_id,
-            name=f"fmap_reports_wf_{clean_bids_id}",
+            name=f"fmap_reports_wf_{estimator.sanitized_id}",
         )
         fmap_reports_wf.inputs.inputnode.source_files = source_files
 
@@ -146,7 +143,7 @@ def init_fmap_preproc_wf(
             fields = INPUT_FIELDS[estimator.method]
             inputnode = pe.Node(
                 niu.IdentityInterface(fields=fields),
-                name=f"in_{clean_bids_id}",
+                name=f"in_{estimator.sanitized_id}",
             )
             # fmt:off
             workflow.connect([

--- a/sdcflows/workflows/fit/base.py
+++ b/sdcflows/workflows/fit/base.py
@@ -25,6 +25,8 @@
 
 def init_sdcflows_wf():
     """Create a multi-subject, multi-estimator *SDCFlows* workflow."""
+    import re
+
     from nipype.pipeline.engine import Workflow
     from niworkflows.utils.bids import collect_participants
 
@@ -51,6 +53,8 @@ def init_sdcflows_wf():
 
     for subject, sub_estimators in estimators_record.items():
         for estim in sub_estimators:
+            clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estim.bids_id)
+
             estim_wf = estim.get_workflow(
                 omp_nthreads=config.nipype.omp_nthreads,
                 sloppy=False,
@@ -61,7 +65,7 @@ def init_sdcflows_wf():
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
                 write_coeff=True,
-                name=f"fmap_derivatives_{estim.bids_id}",
+                name=f"fmap_derivatives_{clean_bids_id}",
             )
 
             source_paths = [
@@ -76,7 +80,7 @@ def init_sdcflows_wf():
                 fmap_type=estim.method,
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
-                name=f"fmap_reports_{estim.bids_id}",
+                name=f"fmap_reports_{clean_bids_id}",
             )
             reportlets_wf.inputs.inputnode.source_files = source_paths
 

--- a/sdcflows/workflows/fit/base.py
+++ b/sdcflows/workflows/fit/base.py
@@ -25,8 +25,6 @@
 
 def init_sdcflows_wf():
     """Create a multi-subject, multi-estimator *SDCFlows* workflow."""
-    import re
-
     from nipype.pipeline.engine import Workflow
     from niworkflows.utils.bids import collect_participants
 
@@ -53,8 +51,6 @@ def init_sdcflows_wf():
 
     for subject, sub_estimators in estimators_record.items():
         for estim in sub_estimators:
-            clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estim.bids_id)
-
             estim_wf = estim.get_workflow(
                 omp_nthreads=config.nipype.omp_nthreads,
                 sloppy=False,
@@ -65,7 +61,7 @@ def init_sdcflows_wf():
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
                 write_coeff=True,
-                name=f"fmap_derivatives_{clean_bids_id}",
+                name=f"fmap_derivatives_{estim.sanitized_id}",
             )
 
             source_paths = [
@@ -80,7 +76,7 @@ def init_sdcflows_wf():
                 fmap_type=estim.method,
                 output_dir=config.execution.output_dir,
                 bids_fmap_id=estim.bids_id,
-                name=f"fmap_reports_{clean_bids_id}",
+                name=f"fmap_reports_{estim.sanitized_id}",
             )
             reportlets_wf.inputs.inputnode.source_files = source_paths
 

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -21,6 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Writing out outputs."""
+import re
+
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from niworkflows.interfaces.bids import DerivativesDataSink as _DDS
@@ -77,7 +79,7 @@ def init_fmap_reports_wf(
 
     custom_entities = custom_entities or {}
     if bids_fmap_id:
-        custom_entities["fmapid"] = bids_fmap_id.replace("_", "")
+        custom_entities["fmapid"] = re.sub(r'[^a-zA-Z0-9]', '', bids_fmap_id)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
@@ -156,7 +158,7 @@ def init_fmap_derivatives_wf(
     """
     custom_entities = custom_entities or {}
     if bids_fmap_id:
-        custom_entities["fmapid"] = bids_fmap_id.replace("_", "")
+        custom_entities["fmapid"] = re.sub(r'[^a-zA-Z0-9]', '', bids_fmap_id)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -23,7 +23,10 @@
 """Test the base workflow."""
 from pathlib import Path
 import os
+import re
+
 import pytest
+
 from sdcflows import fieldmaps as fm
 from sdcflows.utils.wrangler import find_estimators
 from sdcflows.workflows.base import init_fmap_preproc_wf
@@ -55,7 +58,8 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
         if estimator.method != fm.EstimatorType.PEPOLAR:
             continue
 
-        inputnode = wf.get_node(f"in_{estimator.bids_id}")
+        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estimator.bids_id)
+        inputnode = wf.get_node(f"in_{clean_bids_id}")
         inputnode.inputs.in_data = [str(f.path) for f in estimator.sources]
         inputnode.inputs.metadata = [f.metadata for f in estimator.sources]
 

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -23,10 +23,7 @@
 """Test the base workflow."""
 from pathlib import Path
 import os
-import re
-
 import pytest
-
 from sdcflows import fieldmaps as fm
 from sdcflows.utils.wrangler import find_estimators
 from sdcflows.workflows.base import init_fmap_preproc_wf
@@ -58,8 +55,7 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
         if estimator.method != fm.EstimatorType.PEPOLAR:
             continue
 
-        clean_bids_id = re.sub(r'[^a-zA-Z0-9]', '', estimator.bids_id)
-        inputnode = wf.get_node(f"in_{clean_bids_id}")
+        inputnode = wf.get_node(f"in_{estimator.bids_id}")
         inputnode.inputs.in_data = [str(f.path) for f in estimator.sources]
         inputnode.inputs.metadata = [f.metadata for f in estimator.sources]
 


### PR DESCRIPTION
Replaces #434 along the lines described in https://github.com/nipreps/sdcflows/issues/295#issuecomment-2151041189.

I think probably the cleanest way forward for downstream is for functions to always store and pass the estimator object, and select `bids_id` or `sanitized_id` only when a string is needed and what kind of string is needed is known.

TBH, this is a needless headache that is going to invite bugs, and I think we should put a check in the validator warning about `B0Field*` that contains non-alphanumeric characters, including underscores.