### PR TITLE
[FIX] Building Docker image on ARM64 devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN python -m build /src
 #
 
 # Utilities for downloading packages
-FROM ${BASE_IMAGE} as downloader
+FROM --platform=linux/amd64 ${BASE_IMAGE} as downloader
 
 # Bump the date to current to refresh curl/certificates/etc
 RUN echo "2023.11.09"
@@ -100,7 +100,7 @@ RUN /opt/conda/envs/sdcflows/bin/pip install --no-cache-dir -r /tmp/requirements
 #
 # Main stage
 #
-FROM ${BASE_IMAGE} as sdcflows
+FROM --platform=linux/amd64 ${BASE_IMAGE} as sdcflows
 
 # Configure apt
 ENV DEBIAN_FRONTEND="noninteractive" \


### PR DESCRIPTION
Currently, the base image version depends on the platform used to build the Docker image. Building on M1 Macbook fails to create the mamba environment due to `0.370 rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2`. This change prevents the issue by forcing the use of `linux/amd64`, which is currently used for building the images for DockerHub.