### PR TITLE
FIX: Revision of the B-Spline fitting code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,9 +292,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - workdir-v2-{{ .Branch }}-
-            - workdir-v2-master-
-            - workdir-v2-
+            - workdir-v3-{{ .Branch }}-
+            - workdir-v3-master-
+            - workdir-v3-
       - run:
           name: Refreshing cached intermediate results
           working_directory: /tmp/src/sdcflows
@@ -343,7 +343,7 @@ jobs:
                        --cov sdcflows --cov-report xml:/out/unittests.xml \
                        sdcflows/
       - save_cache:
-          key: workdir-v2-{{ .Branch }}-{{ .BuildNum }}
+          key: workdir-v3-{{ .Branch }}-{{ .BuildNum }}
           paths:
             - /tmp/work
       - store_artifacts:

--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -90,6 +90,7 @@ class _BSplineApproxInputSpec(BaseInterfaceInputSpec):
 
 
 class _BSplineApproxOutputSpec(TraitedSpec):
+    out_intercept = traits.Float
     out_field = File(exists=True)
     out_coeff = OutputMultiObject(File(exists=True))
     out_error = File(exists=True)
@@ -226,7 +227,7 @@ class BSplineApprox(SimpleInterface):
                 f"Extreme value {extreme:.2e} detected in spline coefficients."
             )
 
-        LOGGER.info(f"Model fit. Intercept = {model.intercept_}")
+        self._results["out_intercept"] = model.intercept_
 
         # Store coefficients
         index = 0
@@ -273,7 +274,7 @@ class BSplineApprox(SimpleInterface):
         # Write out fitting-error map
         self._results["out_error"] = out_name.replace("_field.", "_error.")
         fmapnii.__class__(
-            data * mask - interp_data, fmapnii.affine, fmapnii.header
+            data * mask - interp_data + model.intercept_, fmapnii.affine, fmapnii.header
         ).to_filename(self._results["out_error"])
 
         if not self.inputs.extrapolate:

--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -65,10 +65,10 @@ class _BSplineApproxInputSpec(BaseInterfaceInputSpec):
         1e-4, usedefault=True, desc="controls the regularization"
     )
     recenter = traits.Enum(
-        False,
-        "mode",
         "median",
+        "mode",
         "mean",
+        False,
         usedefault=True,
         desc="strategy to recenter the distribution of the input fieldmap",
     )

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -339,6 +339,7 @@ def find_estimators(
             "Dataset includes `B0FieldIdentifier` metadata."
             "Any data missing this metadata will be ignored."
         )
+
         for b0_id in b0_ids:
             # Found B0FieldIdentifier metadata entries
             b0_entities = base_entities.copy()

--- a/sdcflows/workflows/fit/fieldmap.py
+++ b/sdcflows/workflows/fit/fieldmap.py
@@ -86,7 +86,6 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     """
     from ...interfaces.bspline import (
         BSplineApprox,
-        DEFAULT_LF_ZOOMS_MM,
         DEFAULT_HF_ZOOMS_MM,
         DEFAULT_ZOOMS_MM,
     )
@@ -115,7 +114,7 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     bs_filter = pe.Node(BSplineApprox(), name="bs_filter")
     bs_filter.interface._always_run = debug
     bs_filter.inputs.bs_spacing = (
-        [DEFAULT_LF_ZOOMS_MM, DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]
+        [DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]
     )
     bs_filter.inputs.extrapolate = not debug
 

--- a/sdcflows/workflows/fit/fieldmap.py
+++ b/sdcflows/workflows/fit/fieldmap.py
@@ -87,7 +87,6 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     from ...interfaces.bspline import (
         BSplineApprox,
         DEFAULT_HF_ZOOMS_MM,
-        DEFAULT_ZOOMS_MM,
     )
     from ...interfaces.fmap import CheckRegister
 
@@ -113,9 +112,11 @@ def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", na
     magnitude_wf = init_magnitude_wf(omp_nthreads=omp_nthreads)
     bs_filter = pe.Node(BSplineApprox(), name="bs_filter")
     bs_filter.interface._always_run = debug
-    bs_filter.inputs.bs_spacing = (
-        [DEFAULT_HF_ZOOMS_MM] if not sloppy else [DEFAULT_ZOOMS_MM]
-    )
+    bs_filter.inputs.bs_spacing = [DEFAULT_HF_ZOOMS_MM]
+
+    if sloppy:
+        bs_filter.inputs.zooms_min = 4.0
+
     bs_filter.inputs.extrapolate = not debug
 
     # fmt: off


### PR DESCRIPTION
Several issues are addressed:

- Fit intercept: instead of removing the mean/median/mode before fitting, let the model account for that by fitting an intercept.
- Lower regularization alpha: it seems the regularization can be much lower when fitting only one level of b-splines
- Update the workflow so only one level of b-splines is fit (multi-level fitting is not working, I believe)