### PR TITLE
ENH: Allow Jacobian correction to be toggled on/off

### DIFF
--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -328,6 +328,11 @@ class _ApplyCoeffsFieldInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="the phase-encoding direction corresponding to in_data",
     )
+    jacobian = traits.Bool(
+        False,
+        usedefault=True,
+        desc="apply Jacobian determinant correction after unwarping",
+    )
     num_threads = traits.Int(nohash=True, desc="number of threads")
     approx = traits.Bool(
         True,
@@ -421,6 +426,7 @@ class ApplyCoeffsField(SimpleInterface):
             self.inputs.in_data,
             self.inputs.pe_dir,
             self.inputs.ro_time,
+            jacobian=self.inputs.jacobian or False,
             xfms=self.inputs.in_xfms or None,
             xfm_data2fmap=data2fmap_xfm,
             approx=self.inputs.approx,

--- a/sdcflows/interfaces/bspline.py
+++ b/sdcflows/interfaces/bspline.py
@@ -426,7 +426,7 @@ class ApplyCoeffsField(SimpleInterface):
             self.inputs.in_data,
             self.inputs.pe_dir,
             self.inputs.ro_time,
-            jacobian=self.inputs.jacobian or False,
+            jacobian=self.inputs.jacobian,
             xfms=self.inputs.in_xfms or None,
             xfm_data2fmap=data2fmap_xfm,
             approx=self.inputs.approx,

--- a/sdcflows/workflows/apply/correction.py
+++ b/sdcflows/workflows/apply/correction.py
@@ -26,7 +26,14 @@ from nipype.interfaces import utility as niu
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 
-def init_unwarp_wf(*, free_mem=None, omp_nthreads=1, debug=False, name="unwarp_wf"):
+def init_unwarp_wf(
+    *,
+    jacobian=True,
+    free_mem=None,
+    omp_nthreads=1,
+    debug=False,
+    name="unwarp_wf",
+):
     r"""
     Set up a workflow that unwarps the input :abbr:`EPI (echo-planar imaging)` dataset.
 
@@ -40,11 +47,13 @@ def init_unwarp_wf(*, free_mem=None, omp_nthreads=1, debug=False, name="unwarp_w
 
     Parameters
     ----------
-    omp_nthreads : :obj:`int`
+    jacobian : :class:`bool`
+        If :obj:`True`, apply Jacobian determinant correction after unwarping.
+    omp_nthreads : :class:`int`
         Maximum number of threads an individual process may use.
-    name : :obj:`str`
+    name : :class:`str`
         Unique name of this workflow.
-    debug : :obj:`bool`
+    debug : :class:`bool`
         Whether to run in *sloppy* mode.
 
     Inputs
@@ -123,7 +132,7 @@ def init_unwarp_wf(*, free_mem=None, omp_nthreads=1, debug=False, name="unwarp_w
         num_threads = omp_nthreads
 
     resample = pe.Node(
-        ApplyCoeffsField(num_threads=num_threads),
+        ApplyCoeffsField(jacobian=jacobian, num_threads=num_threads),
         mem_gb=mem_per_thread * num_threads,
         name="resample",
     )

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -219,7 +219,7 @@ def init_topup_wf(
     from sdcflows.interfaces.bspline import ApplyCoeffsField
 
     # Separate the runs again, as our ApplyCoeffsField corrects them separately
-    unwarp = pe.Node(ApplyCoeffsField(), name="unwarp")
+    unwarp = pe.Node(ApplyCoeffsField(jacobian=True), name="unwarp")
     unwarp.interface._always_run = True
     concat_corrected = pe.Node(MergeSeries(), name="concat_corrected")
 

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -237,7 +237,7 @@ template [@fieldmapless3].
         DisplacementsField2Fieldmap(), name="extract_field"
     )
 
-    unwarp = pe.Node(ApplyCoeffsField(), name="unwarp")
+    unwarp = pe.Node(ApplyCoeffsField(jacobian=False), name="unwarp")
 
     # Check zooms (avoid very expensive B-Splines fitting)
     zooms_field = pe.Node(


### PR DESCRIPTION
Jacobian correction is optional in fMRIPrep, but it can't be toggled when calling SDCFlows resampling, as in SDCFlows workflows. This:

* Allows `ApplyCoeffsField` and `init_unwarp_wf` to take a boolean `jacobian` argument that determine whether the Jacobian will be applied.
* Sets the default for `init_unwarp_wf` to `True` to avoid changing behavior in downstream tools that do not upgrade and decide to disable it.
* Sets the default to `False` for `ApplyCoeffsField`. This seems the more conservative option for an interface.
* Sets `jacobian=True` when adding `ApplyCoeffsField` to the `init_topup_wf` workflow and `jacobian=False` in the `init_syn_sdc_wf`

The main thing this enables is fixing https://github.com/nipreps/fmriprep/issues/3366.