### PR TITLE
ENH: Add `defaults` to `conda` channels in `build-test-publish` GHA

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -129,7 +129,7 @@ jobs:
         auto-update-conda: true
         auto-activate-base: true
         python-version: ${{ matrix.python-version }}
-        channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
+        channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge,defaults
     - uses: actions/cache@v4
       id: conda
       env:


### PR DESCRIPTION
Add `defaults` to the list of `conda` channels when setting up `miniconda` in the build, test, publish GHA workflow file.

Fixes:
```
/usr/share/miniconda/lib/python3.12/site-packages/conda/base/context.py:198:
 FutureWarning: Adding 'defaults' to channel list implicitly is deprecated and will be removed in 25.3.

To remove this warning, please choose a default channel explicitly with
 conda's regular configuration system, e.g. by adding 'defaults' to the list of channels:

  conda config --add channels defaults

For more information see https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/use-condarc.html
```

raised for example in:
https://github.com/nipreps/sdcflows/actions/runs/12413644206