### PR TITLE
ENH: Fix caching-related warnings in GHA `build-test-publish` CI

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
-        path: /var/lib/apt
+        path: ${{ runner.temp }}/cache-linux
         key: apt-cache-v3
         restore-keys: |
           apt-cache-v3
@@ -102,13 +102,16 @@ jobs:
                         libglu1-mesa-dev libglw1-mesa     \
                         libxm4 build-essential
 
-    - uses: actions/cache@v4
+    - name: Restore cache for AFNI
+      id: cache-afni
+      uses: actions/cache@v4
       with:
         path: /opt/afni
-        key: afni-v1
+        key: afni-v1-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.marks }}
         restore-keys: |
-          afni-v1
+          afni-v1-
     - name: Install AFNI
+      if: steps.cache-afni.outputs.cache-hit != 'true'
       run: |
         if [[ ! -d "${AFNI_HOME}" ]]; then
           curl -O https://afni.nimh.nih.gov/pub/dist/bin/misc/@update.afni.binaries && \


### PR DESCRIPTION
Fix caching-related warnings in GHA `build-test-publish` CI:
- Save the `apt-get` cache in a directory other than `/var/lib/apt` to avoid permission issues.
- Make the AFNI cache key name be specific to the CI matrix configuration to avoid clashes across cache names. Use the root part as the restore key name so that any cache found can be restored, as the AFNI version being installed is the same across configurations.
- Check if the AFNI cache exists before trying to install it in GitHub Actions `build-test-publish` CI workflow.

Fixes:
```
Failed to save: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
```

The full log showing
```
2024-12-19T13:35:45.2830631Z
 [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/sdcflows/sdcflows --files-from manifest.txt --use-compress-program zstdmt
2024-12-19T13:35:46.5536670Z
 Failed to save: Unable to reserve cache with key afni-v1, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: afni-v1, Version: d04022ae09f8f21b8c0f9f00e4a784b6e510fe6a47d30aa3b0853a42885b92cb
2024-12-19T13:35:46.5924639Z
 Post job cleanup.
2024-12-19T13:35:46.7348688Z
 [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/sdcflows/sdcflows --files-from manifest.txt --use-compress-program zstdmt
2024-12-19T13:35:46.8326360Z
 /usr/bin/tar: ../../../../../var/lib/apt/lists/lock: Cannot open: Permission denied
2024-12-19T13:35:47.1807249Z
 /usr/bin/tar: ../../../../../var/lib/apt/lists/partial: Cannot open: Permission denied
2024-12-19T13:35:47.2842971Z
 /usr/bin/tar: Exiting with failure status due to previous errors
2024-12-19T13:35:47.2851756Z
 ##[warning]Failed to save: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
```

raised for exmaple in:
https://github.com/nipreps/sdcflows/actions/runs/12413644206