### PR TITLE
ENH: Allow running SyN SDC without using prior

### DIFF
--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -39,6 +39,7 @@ def init_fmap_preproc_wf(
     sloppy=False,
     debug=False,
     name="fmap_preproc_wf",
+    **kwargs,
 ):
     """
     Create and combine estimator workflows.
@@ -110,6 +111,7 @@ def init_fmap_preproc_wf(
             omp_nthreads=omp_nthreads,
             debug=debug,
             sloppy=sloppy,
+            **kwargs,
         )
         source_files = [
             str(f.path) for f in estimator.sources if f.suffix not in ("T1w", "T2w")

--- a/sdcflows/workflows/fit/fieldmap.py
+++ b/sdcflows/workflows/fit/fieldmap.py
@@ -29,7 +29,14 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 INPUT_FIELDS = ("magnitude", "fieldmap")
 
 
-def init_fmap_wf(omp_nthreads=1, sloppy=False, debug=False, mode="phasediff", name="fmap_wf"):
+def init_fmap_wf(
+    omp_nthreads=1,
+    sloppy=False,
+    debug=False,
+    mode="phasediff",
+    name="fmap_wf",
+    **kwargs,
+):
     """
     Estimate the fieldmap based on a field-mapping MRI acquisition.
 

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -40,6 +40,7 @@ def init_topup_wf(
     sloppy=False,
     debug=False,
     name="pepolar_estimate_wf",
+    **kwargs,
 ):
     """
     Create the PEPOLAR field estimation workflow based on FSL's ``topup``.

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -25,6 +25,7 @@ Estimating the susceptibility distortions without fieldmaps.
 """
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
+from nipype.interfaces.base import Undefined
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from ... import data
@@ -526,7 +527,7 @@ def init_syn_preprocessing_wf(
         # no prior to be used
         # MG: Future goal is to allow using alternative mappings
         # i.e. in the case of infants, where priors change depending on development
-        outputnode.inputs.sd_prior = niu.Undefined
+        outputnode.inputs.sd_prior = Undefined
 
     workflow.connect([
         (inputnode, epi_reference_wf, [("in_epis", "inputnode.in_files")]),

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -271,7 +271,6 @@ template [@fieldmapless3].
             (inputnode, atlas_msk, [("sd_prior", "in_file")]),
             (atlas_msk, fixed_masks, [("out_mask", "in3")]),
         ])  # fmt:skip
-
     else:
         workflow.connect(inputnode, "anat_mask", fixed_masks, "in3")
 
@@ -303,7 +302,6 @@ template [@fieldmapless3].
         (lap_epi, lap_epi_norm, [("output_image", "in_file")]),
         (lap_epi_norm, epi_merge, [("out", "in2")]),
         (find_zooms, zooms_epi, [("out", "zooms")]),
-        (atlas_msk, fixed_masks, [("out_mask", "in3")]),
         (anat_dilmsk, amask2epi, [("out_file", "input_image")]),
         (amask2epi, epi_umask, [("output_image", "in2")]),
         (readout_time, warp_dir, [("pe_direction", "pe_dir")]),

--- a/sdcflows/workflows/fit/tests/test_syn.py
+++ b/sdcflows/workflows/fit/tests/test_syn.py
@@ -30,7 +30,8 @@ from ..syn import init_syn_sdc_wf, init_syn_preprocessing_wf, _adjust_zooms, _se
 
 @pytest.mark.veryslow
 @pytest.mark.slow
-def test_syn_wf(tmpdir, datadir, workdir, outdir, sloppy_mode):
+@pytest.mark.parametrize("sd_prior", [True, False])
+def test_syn_wf(tmpdir, datadir, workdir, outdir, sloppy_mode, sd_prior):
     """Build and run an SDC-SyN workflow."""
     derivs_path = datadir / "ds000054" / "derivatives"
     smriprep = derivs_path / "smriprep-0.6" / "sub-100185" / "anat"
@@ -42,6 +43,7 @@ def test_syn_wf(tmpdir, datadir, workdir, outdir, sloppy_mode):
         debug=sloppy_mode,
         auto_bold_nss=True,
         t1w_inversion=True,
+        sd_prior=sd_prior,
     )
     prep_wf.inputs.inputnode.in_epis = [
         str(
@@ -72,7 +74,12 @@ def test_syn_wf(tmpdir, datadir, workdir, outdir, sloppy_mode):
         smriprep / "sub-100185_desc-brain_mask.nii.gz"
     )
 
-    syn_wf = init_syn_sdc_wf(debug=sloppy_mode, sloppy=sloppy_mode, omp_nthreads=4)
+    syn_wf = init_syn_sdc_wf(
+        debug=sloppy_mode,
+        sloppy=sloppy_mode,
+        omp_nthreads=4,
+        sd_prior=sd_prior,
+    )
 
     # fmt: off
     wf.connect([


### PR DESCRIPTION
This PR makes the use of a prior during SyN SDC optional, since distortions may differ depending on population. Eventually, it would be nice to add a range of priors, either within SDCFlows directly or easily plugged in from other tools.

Relevant to https://github.com/nipreps/nibabies/issues/393