### PR TITLE
feat(syn): Update totalFieldVarianceInVoxel space based on voxel resolution

### DIFF
--- a/sdcflows/data/sd_syn.json
+++ b/sdcflows/data/sd_syn.json
@@ -14,7 +14,7 @@
     "shrink_factors": [ [ 1, 1 ], [ 1 ] ],
     "sigma_units": [ "vox", "vox" ],
     "smoothing_sigmas": [ [ 2, 0 ], [ 0 ] ],
-    "transform_parameters": [ [ 0.8, 6.0, 3.0 ], [ 0.8, 2.0, 1.0 ] ],
+    "transform_parameters": [ [ 0.8, 6.0, 10.0 ], [ 0.8, 2.0, 0.5 ] ],
     "transforms": [ "SyN", "SyN" ],
     "use_histogram_matching": [ true, true ],
     "winsorize_lower_quantile": 0.001,

--- a/sdcflows/data/sd_syn_sloppy.json
+++ b/sdcflows/data/sd_syn_sloppy.json
@@ -14,7 +14,7 @@
     "shrink_factors": [ [ 1, 1 ], [ 1 ] ],
     "sigma_units": [ "vox", "vox" ],
     "smoothing_sigmas": [ [ 2, 0 ], [ 0 ] ],
-    "transform_parameters": [ [ 0.8, 6.0, 3.0 ], [ 0.8, 2.0, 1.0 ] ],
+    "transform_parameters": [ [ 0.8, 6.0, 10.0 ], [ 0.8, 2.0, 0.5 ] ],
     "transforms": [ "SyN", "SyN" ],
     "use_histogram_matching": [ true, true ],
     "verbose": true,

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -594,7 +594,7 @@ def init_syn_preprocessing_wf(
     return workflow
 
 
-def _warp_dir(moving_image, fixed_image, pe_dir, nlevels=3):
+def _warp_dir(moving_image, fixed_image, pe_dir, nlevels=2):
     """Extract the ``restrict_deformation`` argument from metadata."""
     import numpy as np
     import nibabel as nb

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -604,6 +604,21 @@ def _warp_dir(fixed_image, pe_dir, nlevels=3):
     return nlevels * [retval.tolist()]
 
 
+def _mm2vox(moving_image, pe_dir, registration_config):
+    import nibabel as nb
+
+    params = registration_config['transform_parameters']
+
+    img = nb.load(moving_image)
+    zooms = nb.affines.voxel_sizes(img.affine)
+    pe_res = zooms["ijk".index(pe_dir[0])]
+
+    return [
+        [*level_params[:2], level_params[2] / pe_res]
+        for level_params in params
+    ]
+
+
 def _merge_meta(epi_ref, meta_list):
     """Prepare a tuple of EPI reference and metadata."""
     return (epi_ref, meta_list[0])


### PR DESCRIPTION
The SyN transform parameters are:

```
SyN[gradientStep,<updateFieldVarianceInVoxelSpace=3>,<totalFieldVarianceInVoxelSpace=0>]
```

The size of estimated displacements should not depend significantly on the voxel size. This change updates the totalFieldVarianceInVoxelSpace to mm values of 10mm and 0.5mm in the `sd_syn.json` files, and adds an interface to convert these to voxels based on the resolution in the phase-encoding direction.