### PR TITLE
FIX: Use the sanitized id when naming through nipype

### DIFF
--- a/sdcflows/transform.py
+++ b/sdcflows/transform.py
@@ -498,7 +498,8 @@ class B0FieldTransform:
             pe_info.append(
                 (
                     pe_axis,
-                    # Displacements are reversed if either is true (after ensuring positive cosines)
+                    # Displacements are reversed if either is true
+                    # (after ensuring positive cosines)
                     -ro_time[volid] if (axis_flip ^ pe_flip) else ro_time[volid],
                 )
             )

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -130,7 +130,7 @@ def init_fmap_preproc_wf(
         source_files = [str(f.path) for f in estimator.sources if f.suffix not in ('T1w', 'T2w')]
 
         out_map = pe.Node(
-            niu.IdentityInterface(fields=out_fields), name=f'out_{estimator.bids_id}'
+            niu.IdentityInterface(fields=out_fields), name=f'out_{estimator.sanitized_id}'
         )
         out_map.inputs.fmap_id = estimator.bids_id
 

--- a/sdcflows/workflows/tests/test_base.py
+++ b/sdcflows/workflows/tests/test_base.py
@@ -57,7 +57,7 @@ def test_fmap_wf(tmpdir, workdir, outdir, bids_layouts, dataset, subject):
         if estimator.method != fm.EstimatorType.PEPOLAR:
             continue
 
-        inputnode = wf.get_node(f'in_{estimator.bids_id}')
+        inputnode = wf.get_node(f'in_{estimator.sanitized_id}')
         inputnode.inputs.in_data = [str(f.path) for f in estimator.sources]
         inputnode.inputs.metadata = [f.metadata for f in estimator.sources]
 


### PR DESCRIPTION
Closes https://github.com/nipreps/fmriprep/issues/3468

Perhaps we can add another dataset with `B0FieldIdentifier` not solely composed of word characters to
https://github.com/nipreps/sdcflows/blob/b4a01f6e2071a538896e228cba9a43c10b8256cb/sdcflows/workflows/tests/test_base.py#L36