### PR TITLE
feat: Add N4 parameters to init_syn_preprocessing_wf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "nipype >= 1.9.0",
     "migas >= 0.4.0",
     "nireports >= 25.0.1",
-    "niworkflows >= 1.11.0",
+    "niworkflows @ git+https://github.com/nipreps/niworkflows.git@refs/pull/971/head",
     "nitransforms >= 25.0.1",
     "numpy >= 2.0",
     "pybids >= 0.16.4",

--- a/sdcflows/workflows/fit/syn.py
+++ b/sdcflows/workflows/fit/syn.py
@@ -348,6 +348,10 @@ def init_syn_preprocessing_wf(
     auto_bold_nss=False,
     t1w_inversion=False,
     sd_prior=True,
+    n4_iterations=(50,) * 5,
+    n4_shrink_factor=4,
+    calculate_n4_spline_grid=False,
+    **kwargs,
 ):
     """
     Prepare EPI references and co-registration to anatomical for SyN.
@@ -470,6 +474,9 @@ def init_syn_preprocessing_wf(
     epi_reference_wf = init_epi_reference_wf(
         omp_nthreads=omp_nthreads,
         auto_bold_nss=auto_bold_nss,
+        n4_iterations=n4_iterations,
+        n4_shrink_factor=n4_shrink_factor,
+        calculate_bspline_grid=calculate_n4_spline_grid,
     )
     epi_brain = pe.Node(BrainExtraction(), name='epi_brain')
     merge_output = pe.Node(


### PR DESCRIPTION
These are changes that are patched in to the epi_reference_wf in SyN-SDC in https://github.com/nipreps/fmriprep-rodents/pull/55/files.

The expected diff would be:

```diff
             syn_preprocessing_wf = init_syn_preprocessing_wf(
                 omp_nthreads=config.nipype.omp_nthreads,
                 debug=config.execution.debug is True,
                 auto_bold_nss=True,
                 t1w_inversion=False,
+                n4_iterations=[50] * 4,
+                n4_shrink_factor=1,
+                calculate_n4_spline_grid=True,
                 name=f"syn_preprocessing_{estimator.bids_id}",
             )
             syn_preprocessing_wf.inputs.inputnode.in_epis = sources
             syn_preprocessing_wf.inputs.inputnode.in_meta = source_meta
-
-            #  The default N4 shrink factor (4) appears to artificially blur values across
-            #  anisotropic voxels. Shrink factors are intended to speed up calculation
-            #  but in most cases, the extra calculation time appears to be minimal.
-            syn_preprocessing_wf.inputs.epi_reference_wf.n4_avgs.shrink_factor = 1
-            #  Similarly, the use of an asymmetric bspline grid improves performance
-            #  in anisotropic voxels, so set INU bspline grid based on voxel size
-            syn_preprocessing_wf.inputs.epi_reference_wf.n4_avgs.args = _bspline_grid(sources[0])
-            # The number of N4 iterations are also reduced.
-            syn_preprocessing_wf.inputs.epi_reference_wf.n4_avgs.n_iterations = [50] * 4
```

cc @eilidhmacnicol 