### PR TITLE
feat: Save mask to derivatives, pass derivatives to outputnode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ ignore = [
   "B019",
   "SIM108",
   "C901",
-  "UP038",
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -172,10 +172,12 @@ def init_fmap_preproc_wf(
                 ("outputnode.fmap_ref", "inputnode.fmap_ref"),
                 ("outputnode.fmap_mask", "inputnode.fmap_mask"),
             ]),
-            (est_wf, out_map, [
-                ("outputnode.fmap", "fmap"),
+            (fmap_derivatives_wf, out_map, [
+                ("outputnode.fieldmap", "fmap"),
                 ("outputnode.fmap_ref", "fmap_ref"),
                 ("outputnode.fmap_coeff", "fmap_coeff"),
+            ]),
+            (est_wf, out_map, [
                 ("outputnode.fmap_mask", "fmap_mask"),
                 ("outputnode.method", "method")
             ]),

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -157,13 +157,10 @@ def init_fmap_preproc_wf(
                 niu.IdentityInterface(fields=fields),
                 name=f'in_{estimator.sanitized_id}',
             )
-            # fmt:off
             workflow.connect([
                 (inputnode, est_wf, [(f, f"inputnode.{f}") for f in fields])
-            ])
-            # fmt:on
+            ])  # fmt:skip
 
-        # fmt:off
         workflow.connect([
             (est_wf, fmap_derivatives_wf, [
                 ("outputnode.fmap", "inputnode.fieldmap"),
@@ -182,8 +179,7 @@ def init_fmap_preproc_wf(
                 ("outputnode.fmap_mask", "fmap_mask"),
                 ("outputnode.method", "method")
             ]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
         for field, mergenode in out_merge.items():
             workflow.connect(out_map, field, mergenode, f'in{n}')

--- a/sdcflows/workflows/base.py
+++ b/sdcflows/workflows/base.py
@@ -137,6 +137,7 @@ def init_fmap_preproc_wf(
         fmap_derivatives_wf = init_fmap_derivatives_wf(
             output_dir=str(output_dir),
             write_coeff=True,
+            write_mask=True,
             bids_fmap_id=estimator.bids_id,
             name=f'fmap_derivatives_wf_{estimator.sanitized_id}',
         )
@@ -166,20 +167,21 @@ def init_fmap_preproc_wf(
                 ("outputnode.fmap", "inputnode.fieldmap"),
                 ("outputnode.fmap_ref", "inputnode.fmap_ref"),
                 ("outputnode.fmap_coeff", "inputnode.fmap_coeff"),
+                ("outputnode.fmap_mask", "inputnode.fmap_mask"),
             ]),
             (est_wf, fmap_reports_wf, [
                 ("outputnode.fmap", "inputnode.fieldmap"),
                 ("outputnode.fmap_ref", "inputnode.fmap_ref"),
                 ("outputnode.fmap_mask", "inputnode.fmap_mask"),
             ]),
+            (est_wf, out_map, [
+                ("outputnode.method", "method")
+            ]),
             (fmap_derivatives_wf, out_map, [
                 ("outputnode.fieldmap", "fmap"),
                 ("outputnode.fmap_ref", "fmap_ref"),
                 ("outputnode.fmap_coeff", "fmap_coeff"),
-            ]),
-            (est_wf, out_map, [
                 ("outputnode.fmap_mask", "fmap_mask"),
-                ("outputnode.method", "method")
             ]),
         ])  # fmt:skip
 

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -163,6 +163,10 @@ def init_fmap_derivatives_wf(
         ),
         name='inputnode',
     )
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['fieldmap', 'fmap_coeff', 'fmap_ref']),
+        name='outputnode',
+    )
 
     merge_fmap = pe.Node(MergeSeries(), name='merge_fmap')
 
@@ -208,6 +212,8 @@ def init_fmap_derivatives_wf(
             (("out_file", _getname), "AnatomicalReference"),
         ]),
         (inputnode, ds_fieldmap, [(("fmap_meta", _selectintent), "IntendedFor")]),
+        (ds_fieldmap, outputnode, [("out_file", "fieldmap")]),
+        (ds_reference, outputnode, [("out_file", "fmap_ref")]),
     ])  # fmt:skip
 
     if not write_coeff:
@@ -235,6 +241,7 @@ def init_fmap_derivatives_wf(
         (inputnode, gen_desc, [("fmap_coeff", "infiles")]),
         (gen_desc, ds_coeff, [("out", "desc")]),
         (ds_coeff, ds_fieldmap, [(("out_file", _getname), "AssociatedCoefficients")]),
+        (ds_coeff, outputnode, [("out_file", "fmap_coeff")]),
     ])  # fmt:skip
 
     return workflow

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -105,7 +105,6 @@ def init_fmap_reports_wf(
     for k, v in custom_entities.items():
         setattr(ds_fmap_report.inputs, k, v)
 
-    # fmt:off
     workflow.connect([
         (inputnode, fmap_rpt, [(("fieldmap", _pop), "fieldmap"),
                                ("fmap_ref", "reference"),
@@ -113,8 +112,7 @@ def init_fmap_reports_wf(
         (fmap_rpt, ds_fmap_report, [("out_report", "in_file")]),
         (inputnode, ds_fmap_report, [("source_files", "source_file")]),
 
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     return workflow
 
@@ -200,7 +198,6 @@ def init_fmap_derivatives_wf(
         setattr(ds_reference.inputs, k, v)
         setattr(ds_fieldmap.inputs, k, v)
 
-    # fmt:off
     workflow.connect([
         (inputnode, merge_fmap, [("fieldmap", "in_files")]),
         (inputnode, ds_reference, [("source_files", "source_file"),
@@ -213,8 +210,7 @@ def init_fmap_derivatives_wf(
             (("out_file", _getname), "AnatomicalReference"),
         ]),
         (inputnode, ds_fieldmap, [(("fmap_meta", _selectintent), "IntendedFor")]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     if not write_coeff:
         return workflow
@@ -236,15 +232,13 @@ def init_fmap_derivatives_wf(
     for k, v in custom_entities.items():
         setattr(ds_coeff.inputs, k, v)
 
-    # fmt:off
     workflow.connect([
         (inputnode, ds_coeff, [("source_files", "source_file"),
                                ("fmap_coeff", "in_file")]),
         (inputnode, gen_desc, [("fmap_coeff", "infiles")]),
         (gen_desc, ds_coeff, [("out", "desc")]),
         (ds_coeff, ds_fieldmap, [(("out_file", _getname), "AssociatedCoefficients")]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     return workflow
 

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -230,6 +230,13 @@ def init_fmap_derivatives_wf(
             ),
             name='ds_mask',
         )
+        ds_mask._interface._file_patterns += (
+            'sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/'
+            'sub-{subject}[_ses-{session}][_hash-{hash}][_acq-{acquisition}]'
+            '[_dir-{direction}][_run-{run}][_part-{part}][_space-{space}]'
+            '[_cohort-{cohort}][_res-{resolution}][_fmapid-{fmapid}]'
+            '[_desc-{desc}]_{suffix<mask>}{extension<.nii|.nii.gz|.json>|.nii.gz}',
+        )
 
         ds_mask.inputs.trait_set(**custom_entities)
 

--- a/sdcflows/workflows/outputs.py
+++ b/sdcflows/workflows/outputs.py
@@ -98,12 +98,11 @@ def init_fmap_reports_wf(
             suffix='fieldmap',
             desc=fmap_type,
             dismiss_entities=('fmap',),
-            allowed_entities=tuple(custom_entities.keys()),
+            allowed_entities=tuple(custom_entities),
         ),
         name='ds_fmap_report',
     )
-    for k, v in custom_entities.items():
-        setattr(ds_fmap_report.inputs, k, v)
+    ds_fmap_report.inputs.trait_set(**custom_entities)
 
     workflow.connect([
         (inputnode, fmap_rpt, [(("fieldmap", _pop), "fieldmap"),
@@ -174,7 +173,7 @@ def init_fmap_derivatives_wf(
             suffix='fieldmap',
             datatype='fmap',
             dismiss_entities=('fmap',),
-            allowed_entities=tuple(custom_entities.keys()),
+            allowed_entities=tuple(custom_entities),
         ),
         name='ds_reference',
     )
@@ -186,7 +185,7 @@ def init_fmap_derivatives_wf(
             suffix='fieldmap',
             datatype='fmap',
             compress=True,
-            allowed_entities=tuple(custom_entities.keys()),
+            allowed_entities=tuple(custom_entities),
         ),
         name='ds_fieldmap',
     )
@@ -194,9 +193,8 @@ def init_fmap_derivatives_wf(
     if bids_fmap_id:
         ds_fieldmap.inputs.B0FieldIdentifier = bids_fmap_id
 
-    for k, v in custom_entities.items():
-        setattr(ds_reference.inputs, k, v)
-        setattr(ds_fieldmap.inputs, k, v)
+    ds_reference.inputs.trait_set(**custom_entities)
+    ds_fieldmap.inputs.trait_set(**custom_entities)
 
     workflow.connect([
         (inputnode, merge_fmap, [("fieldmap", "in_files")]),
@@ -221,7 +219,7 @@ def init_fmap_derivatives_wf(
             suffix='fieldmap',
             datatype='fmap',
             compress=True,
-            allowed_entities=tuple(custom_entities.keys()),
+            allowed_entities=tuple(custom_entities),
         ),
         name='ds_coeff',
         iterfield=('in_file', 'desc'),
@@ -229,8 +227,7 @@ def init_fmap_derivatives_wf(
 
     gen_desc = pe.Node(niu.Function(function=_gendesc), name='gen_desc')
 
-    for k, v in custom_entities.items():
-        setattr(ds_coeff.inputs, k, v)
+    ds_coeff.inputs.trait_set(**custom_entities)
 
     workflow.connect([
         (inputnode, ds_coeff, [("source_files", "source_file"),


### PR DESCRIPTION
sdcflows adopted fit-transform before other nipreps. One thing we've found works well to ensure the same behavior with precomputed derivatives is to save the derivative and pass the saved derivative to the downstream workflow.

This does this for preprocessed fieldmaps, references, coefficients, and (newly) masks. Masks are used by downstream tools to register the fieldmap to the target image. Although they are not needed for application, if the registration is available, they do allow fieldmaps to be precomputed and then used in a new run.

There are a couple cleanup commits in here. The two that are meaningful are labeled `feat:`.

Enabling https://github.com/nipreps/fmriprep/pull/3532.