### PR TITLE
enh: allow selection of motion correction when combining runs

### DIFF
--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -43,6 +43,7 @@ def init_topup_wf(
     debug=False,
     name='pepolar_estimate_wf',
     topup_config=None,
+    mc_method='AFNI',
     **kwargs,
 ):
     """
@@ -156,9 +157,16 @@ def init_topup_wf(
     concat_blips = pe.Node(MergeSeries(affine_tolerance=1e-4), name='concat_blips')
     # Pad dimensions so that they meet TOPUP's expectations
     pad_blip_slices = pe.Node(PadSlices(), name='pad_blip_slices')
-    # Run 3dVolReg between runs: uses RobustAverage for consistency and to generate
+    # uses RobustAverage for consistency and to generate
     # debugging artifacts (typically, one wants to look at the average across uncorrected runs)
-    setwise_avg = pe.Node(RobustAverage(num_threads=omp_nthreads), name='setwise_avg')
+    # default to use AFNI's 3dvolreg, but allow for FSL MCFLIRT.
+    setwise_avg = pe.Node(
+        RobustAverage(
+            mc_method=mc_method,
+            num_threads=omp_nthreads
+        ),
+        name='setwise_avg',
+    )
     # The core of the implementation
     # Feed the input images in LAS orientation, so FSL does not run funky reorientations
     to_las = pe.Node(ReorientImageAndMetadata(target_orientation='LAS'), name='to_las')

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -161,10 +161,7 @@ def init_topup_wf(
     # debugging artifacts (typically, one wants to look at the average across uncorrected runs)
     # default to use AFNI's 3dvolreg, but allow for FSL MCFLIRT.
     setwise_avg = pe.Node(
-        RobustAverage(
-            mc_method=mc_method,
-            num_threads=omp_nthreads
-        ),
+        RobustAverage(mc_method=mc_method, num_threads=omp_nthreads),
         name='setwise_avg',
     )
     # The core of the implementation


### PR DESCRIPTION
Inspired by https://github.com/nipreps/nibabies/issues/542#issuecomment-4373685377

Adds a new parameter `mc_method` to `init_topup_wf` to allow alternative motion correction when combining across phase encoding directions. 

From the 3dvolreg documentation:
> Algorithm: Iterated linearized weighted least squares to make each
              sub-brick as like as possible to the base brick.
              This method is useful for finding SMALL MOTIONS ONLY.

No alternative cost function is available for 3dvolreg, whereas MCFLIRT's normcorr may be more robust (especially in infants).