### PR TITLE
ENH: Couple head motion and susceptibility distortion within TOPUP

### DIFF
--- a/sdcflows/data/flirtsch/b02b0_1_quick.cnf
+++ b/sdcflows/data/flirtsch/b02b0_1_quick.cnf
@@ -1,0 +1,26 @@
+# Resolution (knot-spacing) of warps in mm
+--warpres=20,14,10
+# Subsampling level (a value of 2 indicates that a 2x2x2 neighbourhood is collapsed to 1 voxel)
+--subsamp=1,1,1
+# FWHM of gaussian smoothing
+--fwhm=8,2,1
+# Maximum number of iterations
+--miter=5,5,5
+# Relative weight of regularisation
+--lambda=0.0005,0.000005,0.0000005
+# If set to 1 lambda is multiplied by the current average squared difference
+--ssqlambda=1
+# Regularisation model
+--regmod=bending_energy
+# If set to 1 movements are estimated along with the field
+--estmov=1,1,0
+# 0=Levenberg-Marquardt, 1=Scaled Conjugate Gradient
+--minmet=0,0,1
+# Quadratic or cubic splines
+--splineorder=3
+# Precision for calculation and storage of Hessian
+--numprec=double
+# Linear or spline interpolation
+--interp=spline
+# If set to 1 the images are individually scaled to a common mean intensity
+--scale=1

--- a/sdcflows/data/flirtsch/b02b0_2_quick.cnf
+++ b/sdcflows/data/flirtsch/b02b0_2_quick.cnf
@@ -1,0 +1,26 @@
+# Resolution (knot-spacing) of warps in mm
+--warpres=20,14,10
+# Subsampling level (a value of 2 indicates that a 2x2x2 neighbourhood is collapsed to 1 voxel)
+--subsamp=2,2,2
+# FWHM of gaussian smoothing
+--fwhm=8,2,1
+# Maximum number of iterations
+--miter=5,5,5
+# Relative weight of regularisation
+--lambda=0.005,0.000005,0.0000005
+# If set to 1 lambda is multiplied by the current average squared difference
+--ssqlambda=1
+# Regularisation model
+--regmod=bending_energy
+# If set to 1 movements are estimated along with the field
+--estmov=1,1,0
+# 0=Levenberg-Marquardt, 1=Scaled Conjugate Gradient
+--minmet=0,0,1
+# Quadratic or cubic splines
+--splineorder=3
+# Precision for calculation and storage of Hessian
+--numprec=double
+# Linear or spline interpolation
+--interp=spline
+# If set to 1 the images are individually scaled to a common mean intensity
+--scale=1

--- a/sdcflows/data/flirtsch/b02b0_4_quick.cnf
+++ b/sdcflows/data/flirtsch/b02b0_4_quick.cnf
@@ -1,0 +1,26 @@
+# Resolution (knot-spacing) of warps in mm
+--warpres=20,14,10
+# Subsampling level (a value of 2 indicates that a 2x2x2 neighbourhood is collapsed to 1 voxel)
+--subsamp=4,2,1
+# FWHM of gaussian smoothing
+--fwhm=8,2,1
+# Maximum number of iterations
+--miter=5,5,5
+# Relative weight of regularisation
+--lambda=0.035,0.000005,0.0000005
+# If set to 1 lambda is multiplied by the current average squared difference
+--ssqlambda=1
+# Regularisation model
+--regmod=bending_energy
+# If set to 1 movements are estimated along with the field
+--estmov=1,1,0
+# 0=Levenberg-Marquardt, 1=Scaled Conjugate Gradient
+--minmet=0,0,1
+# Quadratic or cubic splines
+--splineorder=3
+# Precision for calculation and storage of Hessian
+--numprec=double
+# Linear or spline interpolation
+--interp=spline
+# If set to 1 the images are individually scaled to a common mean intensity
+--scale=1

--- a/sdcflows/interfaces/epi.py
+++ b/sdcflows/interfaces/epi.py
@@ -74,6 +74,95 @@ class GetReadoutTime(SimpleInterface):
         return runtime
 
 
+class _SelectPEVolumesInputSpec(BaseInterfaceInputSpec):
+    in_data = InputMultiObject(
+        File(exists=True),
+        mandatory=True,
+        desc='list of input EPI files (3D or 4D), in the order they were listed',
+    )
+    pe_dirs_fsl = InputMultiObject(
+        traits.Enum('x', 'x-', 'y', 'y-', 'z', 'z-'),
+        mandatory=True,
+        desc="per-file PE directions, in FSL's conventions",
+    )
+    readout_times = InputMultiObject(
+        traits.Float, mandatory=True, desc='per-file total readout times'
+    )
+    max_vols_per_pe = traits.Int(
+        3,
+        usedefault=True,
+        desc='maximum number of volumes to keep for each PE direction',
+    )
+
+
+class _SelectPEVolumesOutputSpec(TraitedSpec):
+    out_data = OutputMultiObject(File(exists=True), desc='selected 3D volumes')
+    pe_dirs_fsl = OutputMultiObject(
+        traits.Enum('x', 'x-', 'y', 'y-', 'z', 'z-'),
+        desc="per-volume PE directions, in FSL's conventions",
+    )
+    readout_times = OutputMultiObject(traits.Float, desc='per-volume total readout times')
+
+
+class SelectPEVolumes(SimpleInterface):
+    """
+    Limit the data fed into TOPUP to a few volumes per phase-encoding direction.
+
+    FSL's ``topup`` documentation recommends acquiring (and using) only a handful
+    of volumes per PE direction, kept as "spares" against intra-volume motion that
+    ``topup``'s own movement model then resolves. It also notes that passing more than a
+    single opposing pair *"doesn't seem to make any difference, and only means that
+    topup takes longer to run"*.
+
+    This interface walks the input runs in the order they are listed, splits any 4D
+    runs into their constituent 3D volumes, and keeps at most ``max_vols_per_pe``
+    volumes for each PE direction (e.g. 3 blip-up and 3 blip-down). Once a
+    direction's budget is full, any remaining volumes — and any additional runs of
+    the same polarity — are dropped. Per-volume PE directions and readout times are
+    propagated so that ``topup`` receives one acquisition-parameters row per volume.
+
+    """
+
+    input_spec = _SelectPEVolumesInputSpec
+    output_spec = _SelectPEVolumesOutputSpec
+
+    def _run_interface(self, runtime):
+        from collections import defaultdict
+
+        import nibabel as nb
+        from nipype.utils.filemanip import fname_presuffix
+
+        kept = defaultdict(int)
+        out_data, out_pe_dirs, out_readout_times = [], [], []
+
+        for in_file, pe_dir, readout_time in zip(
+            self.inputs.in_data,
+            self.inputs.pe_dirs_fsl,
+            self.inputs.readout_times,
+            strict=False,
+        ):
+            remaining = self.inputs.max_vols_per_pe - kept[pe_dir]
+            if remaining <= 0:
+                continue
+
+            img = nb.squeeze_image(nb.load(in_file))
+            volumes = nb.four_to_three(img) if img.ndim == 4 else [img]
+
+            for i, volume in enumerate(volumes[:remaining]):
+                out_file = fname_presuffix(in_file, suffix=f'_vol{i}', newpath=runtime.cwd)
+                volume.to_filename(out_file)
+                out_data.append(out_file)
+                out_pe_dirs.append(pe_dir)
+                out_readout_times.append(readout_time)
+
+            kept[pe_dir] += min(remaining, len(volumes))
+
+        self._results['out_data'] = out_data
+        self._results['pe_dirs_fsl'] = out_pe_dirs
+        self._results['readout_times'] = out_readout_times
+        return runtime
+
+
 class _SortPEBlipsInputSpec(BaseInterfaceInputSpec):
     in_data = InputMultiObject(
         File(exists=True),

--- a/sdcflows/interfaces/epi.py
+++ b/sdcflows/interfaces/epi.py
@@ -139,7 +139,7 @@ class SelectPEVolumes(SimpleInterface):
             self.inputs.in_data,
             self.inputs.pe_dirs_fsl,
             self.inputs.readout_times,
-            strict=False,
+            strict=True,
         ):
             remaining = self.inputs.max_vols_per_pe - kept[pe_dir]
             if remaining <= 0:

--- a/sdcflows/interfaces/tests/test_epi.py
+++ b/sdcflows/interfaces/tests/test_epi.py
@@ -24,7 +24,54 @@
 
 from pathlib import Path
 
-from ..epi import SortPEBlips
+import nibabel as nb
+import numpy as np
+
+from ..epi import SelectPEVolumes, SortPEBlips
+
+
+def _write_epi(path, nvols):
+    shape = (4, 4, 4, nvols) if nvols > 1 else (4, 4, 4)
+    nb.Nifti1Image(np.zeros(shape, dtype='float32'), np.eye(4)).to_filename(path)
+    return str(path)
+
+
+def test_select_pe_volumes_caps(tmp_path, monkeypatch):
+    """At most ``max_vols_per_pe`` volumes are kept for each PE direction."""
+    monkeypatch.chdir(tmp_path)
+    ap = _write_epi(tmp_path / 'ap.nii.gz', 10)
+    pa = _write_epi(tmp_path / 'pa.nii.gz', 10)
+
+    result = SelectPEVolumes(
+        in_data=[ap, pa],
+        pe_dirs_fsl=['y', 'y-'],
+        readout_times=[0.05, 0.05],
+    ).run()
+
+    assert result.outputs.pe_dirs_fsl == ['y', 'y', 'y', 'y-', 'y-', 'y-']
+    assert result.outputs.readout_times == [0.05] * 6
+    assert all(nb.load(f).ndim == 3 for f in result.outputs.out_data)
+
+
+def test_select_pe_volumes_order(tmp_path, monkeypatch):
+    """The per-direction budget is filled across runs in the listed order."""
+    monkeypatch.chdir(tmp_path)
+    ap1 = _write_epi(tmp_path / 'ap1.nii.gz', 2)
+    ap2 = _write_epi(tmp_path / 'ap2.nii.gz', 5)
+    pa = _write_epi(tmp_path / 'pa.nii.gz', 5)
+
+    result = SelectPEVolumes(
+        in_data=[ap1, ap2, pa],
+        pe_dirs_fsl=['y', 'y', 'y-'],
+        readout_times=[0.05, 0.05, 0.05],
+        max_vols_per_pe=3,
+    ).run()
+
+    names = [Path(f).name for f in result.outputs.out_data]
+    assert result.outputs.pe_dirs_fsl == ['y', 'y', 'y', 'y-', 'y-', 'y-']
+    assert names[0].startswith('ap1') and names[1].startswith('ap1')
+    assert names[2].startswith('ap2')
+    assert names[3].startswith('pa')
 
 
 def test_sort_pe_blips(tmpdir):

--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -21,7 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Utilities."""
-
+import logging
 from itertools import product
 
 from nipype.interfaces.ants.segmentation import (
@@ -45,6 +45,7 @@ from nipype.interfaces.mixins import CopyHeaderInterface as _CopyHeaderInterface
 from sdcflows.utils.tools import reorient_pedir
 
 OBLIQUE_THRESHOLD_DEG = 0.5
+LOGGER = logging.getLogger('nipype.interface')
 
 
 class _FlattenInputSpec(BaseInterfaceInputSpec):
@@ -128,6 +129,7 @@ class UniformGrid(SimpleInterface):
         refaff = refnii.affine
 
         resampler = Affine(reference=refnii)
+        resampled = []
         for i, fname in enumerate(self.inputs.in_data):
             if retval[i] is not None:
                 continue
@@ -143,12 +145,25 @@ class UniformGrid(SimpleInterface):
                     nii.__class__(nii.dataobj, refaff, nii.header).to_filename(retval[i])
                 continue
 
+            # The input is genuinely on a different sampling grid and must be resampled.
+            resampled.append(fname)
             # Hack around nitransforms' unsafe cast by dropping get_data_dtype that conflicts
             # with effective dtype
             # NT23_0_1: Isssue in nitransforms.base.TransformBase.apply
             regridded_img = resampler.apply(nii.__class__(np.asanyarray(nii.dataobj), nii.affine))
             # Restore the original on-disk data type
             nii.__class__(regridded_img.dataobj, refaff, nii.header).to_filename(retval[i])
+
+        if resampled:
+            LOGGER.warning(
+                'UniformGrid resampled %d input image(s) onto the reference grid because '
+                'they were not on a common sampling grid: %s. When feeding TOPUP, the total '
+                'readout time is referenced to the original acquisition grid, so resampling '
+                'opposing phase-encoding runs that differ in matrix size or voxel spacing may '
+                'bias the estimated field. Verify that these inputs belong together.',
+                len(resampled),
+                ', '.join(resampled),
+            )
 
         self._results['out_data'] = retval
 

--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -130,7 +130,7 @@ class UniformGrid(SimpleInterface):
         refaff = refnii.affine
 
         resampler = Affine(reference=refnii)
-        resampled = []
+        resampled = []  # Catch differing rotational affines
         for i, fname in enumerate(self.inputs.in_data):
             if retval[i] is not None:
                 continue
@@ -147,7 +147,8 @@ class UniformGrid(SimpleInterface):
                 continue
 
             # The input is genuinely on a different sampling grid and must be resampled.
-            resampled.append(fname)
+            if not np.allclose(nii.affine[:3, :3], refaff[:3, :3]):
+                resampled.append(fname)
             # Hack around nitransforms' unsafe cast by dropping get_data_dtype that conflicts
             # with effective dtype
             # NT23_0_1: Isssue in nitransforms.base.TransformBase.apply

--- a/sdcflows/interfaces/utils.py
+++ b/sdcflows/interfaces/utils.py
@@ -21,6 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Utilities."""
+
 import logging
 from itertools import product
 

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -238,21 +238,24 @@ def init_topup_wf(
         # fmt: on
         return workflow
 
-    from niworkflows.interfaces.nibabel import SplitSeries
-
     from sdcflows.interfaces.bspline import ApplyCoeffsField
 
-    # Separate the runs again, as our ApplyCoeffsField corrects them separately
-    split_blips = pe.Node(SplitSeries(), name='split_blips')
     unwarp = pe.Node(ApplyCoeffsField(jacobian=True), name='unwarp')
     unwarp.interface._always_run = True
     concat_corrected = pe.Node(MergeSeries(), name='concat_corrected')
+    convert_xfms = pe.Node(
+        niu.Function(function=_topup_mats_to_world, output_names=['out_xfms']),
+        name='convert_xfms',
+        run_without_submitting=True,
+    )
 
     # fmt:off
     workflow.connect([
-        (concat_blips, split_blips, [("out_file", "in_file")]),
-        (split_blips, unwarp, [("out_files", "in_data")]),
+        (concat_blips, unwarp, [("out_file", "in_data")]),
         (fix_coeff, unwarp, [("out_coeff", "in_coeff")]),
+        (topup, convert_xfms, [("out_mats", "in_mats")]),
+        (to_las, convert_xfms, [("out_file", "in_reference")]),
+        (convert_xfms, unwarp, [("out_xfms", "in_xfms")]),
         (sort_pe_blips, unwarp, [("readout_times", "ro_time"),
                                  ("pe_dirs", "pe_dir")]),
         (unwarp, outputnode, [("out_field", "fmap")]),
@@ -468,6 +471,23 @@ def _select_topup_config(in_file, sloppy=False):
         tier = '1'
 
     return str(load_data(f'flirtsch/b02b0_{tier}{"_quick" * sloppy}.cnf'))
+
+
+def _topup_mats_to_world(in_mats, in_reference):
+    """
+    Convert TOPUP's per-volume FSL motion matrices to world (RAS) affines.
+
+    ``in_reference`` MUST be the image TOPUP realigned (the LAS-reoriented input):
+    FSL matrices live in the voxel frame they were estimated in, so the same matrix
+    yields a different physical transform under a different orientation. The resulting
+    RAS-to-RAS affines are orientation-agnostic.
+    """
+    import nitransforms as nt
+
+    return [
+        nt.linear.load(mat, fmt='fsl', reference=in_reference, moving=in_reference).matrix.tolist()
+        for mat in in_mats
+    ]
 
 
 def _sorted_pe(inlist):

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -147,10 +147,8 @@ def init_topup_wf(
     )
     if fallback_total_readout_time is not None:
         readout_time.inputs.fallback = fallback_total_readout_time
-    # Keep only a few volumes per PE direction so topup is not overwhelmed
-    # FSL recommendation: (~3 spares/direction; extra pairs just increase runtime).
+    # Cap volumes per PE direction so topup isn't overwhelmed (FSL: ~3 spares/dir)
     # https://fsl.fmrib.ox.ac.uk/fsl/docs/diffusion/topup/users_guide/index.html
-    # Runs are split into volumes and the per-direction budget is filled in listed order.
     select_volumes = pe.Node(
         SelectPEVolumes(max_vols_per_pe=max_vols_per_pe), name='select_volumes'
     )

--- a/sdcflows/workflows/fit/pepolar.py
+++ b/sdcflows/workflows/fit/pepolar.py
@@ -43,7 +43,7 @@ def init_topup_wf(
     debug=False,
     name='pepolar_estimate_wf',
     topup_config=None,
-    mc_method='AFNI',
+    max_vols_per_pe=3,
     **kwargs,
 ):
     """
@@ -90,8 +90,16 @@ def init_topup_wf(
         The path of mask corresponding to the ``fmap_ref`` output.
     fmap_coeff : :obj:`str` or :obj:`list` of :obj:`str`
         The path(s) of the B-Spline coefficients supporting the fieldmap.
+    xfms : :obj:`list` of :obj:`str`
+        The path(s) of the per-volume head-motion estimates.
+    out_warps : :obj:`list` of :obj:`str`
+        The path(s) of the per-volume displacement fields.
+    jacobians : :obj:`list` of :obj:`str`
+        The path(s) of the Jacobian determinant maps.
     method: :obj:`str`
         Short description of the estimation method that was run.
+    topup_config : :obj:`str`
+        The path of the config file used for TOPUP.
 
     """
     from nipype.interfaces.fsl.epi import TOPUP
@@ -99,8 +107,8 @@ def init_topup_wf(
     from niworkflows.interfaces.nibabel import MergeSeries, ReorientImage
 
     from ...interfaces.bspline import TOPUPCoeffReorient
-    from ...interfaces.epi import GetReadoutTime, SortPEBlips
-    from ...interfaces.utils import PadSlices, ReorientImageAndMetadata, UniformGrid
+    from ...interfaces.epi import GetReadoutTime, SelectPEVolumes, SortPEBlips
+    from ...interfaces.utils import ReorientImageAndMetadata, UniformGrid
     from ...utils.misc import front as _front
     from ..ancillary import init_brainextraction_wf
 
@@ -108,11 +116,6 @@ def init_topup_wf(
     workflow.__desc__ = f"""\
 {_PEPOLAR_DESC} with `topup` (@topup; FSL {TOPUP().version}).
 """
-
-    if topup_config is None:
-        topup_config = data.load(f'flirtsch/b02b0{"_quick" * sloppy}.cnf')
-    else:
-        workflow.__desc__ += ' A custom `topup` configuration file was used.'
 
     inputnode = pe.Node(niu.IdentityInterface(fields=INPUT_FIELDS), name='inputnode')
     outputnode = pe.Node(
@@ -126,6 +129,7 @@ def init_topup_wf(
                 'xfms',
                 'out_warps',
                 'method',
+                'topup_config',
             ]
         ),
         name='outputnode',
@@ -143,11 +147,12 @@ def init_topup_wf(
     )
     if fallback_total_readout_time is not None:
         readout_time.inputs.fallback = fallback_total_readout_time
-    # Average each run so that topup is not overwhelmed (see #279)
-    runwise_avg = pe.MapNode(
-        RobustAverage(num_threads=omp_nthreads),
-        name='runwise_avg',
-        iterfield='in_file',
+    # Keep only a few volumes per PE direction so topup is not overwhelmed
+    # FSL recommendation: (~3 spares/direction; extra pairs just increase runtime).
+    # https://fsl.fmrib.ox.ac.uk/fsl/docs/diffusion/topup/users_guide/index.html
+    # Runs are split into volumes and the per-direction budget is filled in listed order.
+    select_volumes = pe.Node(
+        SelectPEVolumes(max_vols_per_pe=max_vols_per_pe), name='select_volumes'
     )
     # Regrid all to the reference (grid_reference=0 means first averaged run)
     regrid = pe.Node(UniformGrid(reference=grid_reference), name='regrid')
@@ -155,22 +160,11 @@ def init_topup_wf(
     sort_pe_blips = pe.Node(SortPEBlips(), name='sort_pe_blips', run_without_submitting=True)
     # Merge into one 4D file
     concat_blips = pe.Node(MergeSeries(affine_tolerance=1e-4), name='concat_blips')
-    # Pad dimensions so that they meet TOPUP's expectations
-    pad_blip_slices = pe.Node(PadSlices(), name='pad_blip_slices')
-    # uses RobustAverage for consistency and to generate
-    # debugging artifacts (typically, one wants to look at the average across uncorrected runs)
-    # default to use AFNI's 3dvolreg, but allow for FSL MCFLIRT.
-    setwise_avg = pe.Node(
-        RobustAverage(mc_method=mc_method, num_threads=omp_nthreads),
-        name='setwise_avg',
-    )
-    # The core of the implementation
     # Feed the input images in LAS orientation, so FSL does not run funky reorientations
     to_las = pe.Node(ReorientImageAndMetadata(target_orientation='LAS'), name='to_las')
-    topup = pe.Node(
-        TOPUP(config=str(topup_config)),
-        name='topup',
-    )
+    # TOPUP will jointly estimate head motion and susceptibility distortion using the
+    # default configuration files.
+    topup = pe.Node(TOPUP(), name='topup')
     # "Generalize" topup coefficients and store them in a spatially-correct NIfTI file
     fix_coeff = pe.Node(TOPUPCoeffReorient(), name='fix_coeff', run_without_submitting=True)
 
@@ -180,21 +174,20 @@ def init_topup_wf(
     # Sophisticated brain extraction of fMRIPrep
     brainextraction_wf = init_brainextraction_wf()
 
-    # fmt: off
     workflow.connect([
-        (inputnode, runwise_avg, [("in_data", "in_file")]),
-        (inputnode, readout_time, [("metadata", "metadata")]),
-        (runwise_avg, regrid, [("out_file", "in_data")]),
-        (regrid, readout_time, [("out_data", "in_file")]),
+        (inputnode, readout_time, [("in_data", "in_file"),
+                                   ("metadata", "metadata")]),
+        (inputnode, select_volumes, [("in_data", "in_data")]),
+        (readout_time, select_volumes, [("pe_dir_fsl", "pe_dirs_fsl"),
+                                        ("readout_time", "readout_times")]),
+        (select_volumes, regrid, [("out_data", "in_data")]),
+        (select_volumes, sort_pe_blips, [("pe_dirs_fsl", "pe_dirs_fsl"),
+                                         ("readout_times", "readout_times")]),
         (regrid, sort_pe_blips, [("out_data", "in_data")]),
-        (readout_time, sort_pe_blips, [("readout_time", "readout_times"),
-                                       ("pe_dir_fsl", "pe_dirs_fsl")]),
         (sort_pe_blips, topup, [("readout_times", "readout_times")]),
-        (setwise_avg, fix_coeff, [("out_file", "fmap_ref")]),
+        (regrid, fix_coeff, [("reference", "fmap_ref")]),
         (sort_pe_blips, concat_blips, [("out_data", "in_files")]),
-        (concat_blips, pad_blip_slices, [("out_file", "in_file")]),
-        (pad_blip_slices, setwise_avg, [("out_file", "in_file")]),
-        (setwise_avg, to_las, [("out_hmc_volumes", "in_file")]),
+        (concat_blips, to_las, [("out_file", "in_file")]),
         (sort_pe_blips, to_las, [("pe_dirs_fsl", "pe_dir")]),
         (to_las, topup, [
             ("out_file", "in_file"),
@@ -210,8 +203,25 @@ def init_topup_wf(
             ("outputnode.out_mask", "fmap_mask")
         ]),
         (fix_coeff, outputnode, [("out_coeff", "fmap_coeff")]),
-    ])
-    # fmt: on
+    ])  # fmt: skip
+
+    # When no custom config is given, select the fastest appropriate config at runtime
+    if topup_config:
+        topup.inputs.config = str(topup_config)
+        workflow.__desc__ += ' A custom `topup` configuration file was used.'
+        outputnode.inputs.topup_config = str(topup_config)
+    else:
+        select_config = pe.Node(
+            niu.Function(function=_select_topup_config, output_names=['config']),
+            name='select_config',
+            run_without_submitting=True,
+        )
+        select_config.inputs.sloppy = sloppy
+        workflow.connect([
+            (to_las, select_config, [('out_file', 'in_file')]),
+            (select_config, topup, [('config', 'config')]),
+            (select_config, outputnode, [('config', 'topup_config')]),
+        ])  # fmt: skip
 
     if not debug:
         # Roll orientation back to original
@@ -219,8 +229,8 @@ def init_topup_wf(
         from_las_fmap = pe.Node(ReorientImage(), name='from_las_fmap')
         # fmt: off
         workflow.connect([
-            (setwise_avg, from_las, [("out_file", "target_file")]),
-            (setwise_avg, from_las_fmap, [("out_file", "target_file")]),
+            (regrid, from_las, [("reference", "target_file")]),
+            (regrid, from_las_fmap, [("reference", "target_file")]),
             (topup, from_las, [("out_corrected", "in_file")]),
             (from_las, ref_average, [("out_file", "in_file")]),
             (topup, from_las_fmap, [("out_field", "in_file")]),
@@ -230,17 +240,21 @@ def init_topup_wf(
         # fmt: on
         return workflow
 
+    from niworkflows.interfaces.nibabel import SplitSeries
+
     from sdcflows.interfaces.bspline import ApplyCoeffsField
 
     # Separate the runs again, as our ApplyCoeffsField corrects them separately
+    split_blips = pe.Node(SplitSeries(), name='split_blips')
     unwarp = pe.Node(ApplyCoeffsField(jacobian=True), name='unwarp')
     unwarp.interface._always_run = True
     concat_corrected = pe.Node(MergeSeries(), name='concat_corrected')
 
     # fmt:off
     workflow.connect([
+        (concat_blips, split_blips, [("out_file", "in_file")]),
+        (split_blips, unwarp, [("out_files", "in_data")]),
         (fix_coeff, unwarp, [("out_coeff", "in_coeff")]),
-        (setwise_avg, unwarp, [("out_hmc_volumes", "in_data")]),
         (sort_pe_blips, unwarp, [("readout_times", "ro_time"),
                                  ("pe_dirs", "pe_dir")]),
         (unwarp, outputnode, [("out_field", "fmap")]),
@@ -397,6 +411,65 @@ def init_3dQwarp_wf(omp_nthreads=1, debug=False, name='pepolar_estimate_wf'):
     ])
     # fmt: on
     return workflow
+
+
+def _select_topup_config(in_file, sloppy=False):
+    """
+    Pick an appropriate ``topup`` configuration for the input grid.
+
+    TOPUP's ``--subsamp`` schedule collapses a ``s x s x s`` neighborhood into a
+    single voxel at each level, so *every* image dimension must be divisible by the
+    subsampling factor ``s`` used at that level (otherwise TOPUP errors out or
+    segfaults). Previously, the workaround was zero-padding the troublesome dimensions
+    to an even number of slices; however, later TOPUP releases conceded this was not ideal
+    and now recommend using the config file that best matches the grid.
+
+    The three stock configs differ **only** in two parameters; every other setting is identical:
+
+    +----------------+---------------------------+-----------------------------+
+    | config         | ``--subsamp``             | ``--lambda``                |
+    |                | (max factor → constraint) | (regularization weight)     |
+    +================+===========================+=============================+
+    | ``b02b0_1``    | ``1,1,1,1,1,1,1,1,1``     | ``0.0005, 0.0001, ...``     |
+    |                | (no subsampling; any dim) |                             |
+    +----------------+---------------------------+-----------------------------+
+    | ``b02b0_2``    | ``2,2,2,2,2,1,1,1,1``     | ``0.005, 0.001, ...``       |
+    |                | (all dims divisible by 2) |                             |
+    +----------------+---------------------------+-----------------------------+
+    | ``b02b0_4``    | ``4,4,2,2,2,1,1,1,1``     | ``0.035, 0.006, ...``       |
+    |                | (all dims divisible by 4) |                             |
+    +----------------+---------------------------+-----------------------------+
+
+    Coarser subsampling needs a heavier initial regularization weight (hence the
+    larger leading ``--lambda`` values), which is why each tier ships its own
+    ``--lambda`` schedule rather than reusing a single one. Aggressiveness (and
+    therefore speed) increases down the table, at the cost of a stricter
+    divisibility requirement, so we pick the largest factor the grid allows:
+
+    * all dimensions divisible by four → ``b02b0_4.cnf`` (fastest)
+    * all dimensions even → ``b02b0_2.cnf``
+    * otherwise (any odd dimension) → ``b02b0_1.cnf`` (always safe)
+
+    When ``sloppy`` is ``True``, the corresponding ``_quick`` variant is returned.
+    The ``_quick`` configs are 3-level versions of the above
+    (``--subsamp`` = ``1,1,1`` / ``2,2,2`` / ``4,2,1`` respectively) that keep the
+    same per-tier ``--lambda`` tiering and estimate motion only in the first two
+    levels (``--estmov=1,1,0``) to trade accuracy for speed in debug runs.
+
+    """
+    import nibabel as nb
+
+    from sdcflows.data import load as load_data
+
+    dims = nb.load(in_file).shape[:3]
+    if all(d % 4 == 0 for d in dims):
+        tier = '4'
+    elif all(d % 2 == 0 for d in dims):
+        tier = '2'
+    else:
+        tier = '1'
+
+    return str(load_data(f'flirtsch/b02b0_{tier}{"_quick" * sloppy}.cnf'))
 
 
 def _sorted_pe(inlist):

--- a/sdcflows/workflows/fit/tests/test_pepolar.py
+++ b/sdcflows/workflows/fit/tests/test_pepolar.py
@@ -22,26 +22,49 @@
 #
 """Test pepolar type of fieldmaps."""
 
-import pathlib
+from pathlib import Path
 
+import nibabel as nb
+import numpy as np
 import pytest
 from nipype.pipeline import engine as pe
 
-from ..pepolar import init_topup_wf
+from ..pepolar import _select_topup_config, init_topup_wf
 
 
 @pytest.mark.parametrize(
     'topup_config',
     [
-        None,
         '/path/to/custom.cnf',
-        pathlib.Path('/path/to/custom.cnf'),
+        Path('/path/to/custom.cnf'),
     ],
 )
 def test_topup_config(topup_config):
-    """Ensure the topup node always receives a str config, not a Path."""
+    """Ensure a custom topup config is passed to the node as a str, not a Path."""
     wf = init_topup_wf(topup_config=topup_config)
     assert isinstance(wf.get_node('topup').inputs.config, str), 'topup config must be str'
+
+
+@pytest.mark.parametrize(
+    ('shape', 'sloppy', 'expected'),
+    [
+        ((50, 50, 50), False, 'b02b0_2.cnf'),
+        ((51, 50, 50), False, 'b02b0_1.cnf'),
+        ((48, 48, 48), False, 'b02b0_4.cnf'),
+        ((50, 50, 50), True, 'b02b0_2_quick.cnf'),
+        ((51, 50, 50), True, 'b02b0_1_quick.cnf'),
+        ((48, 48, 48), True, 'b02b0_4_quick.cnf'),
+    ],
+)
+def test_select_topup_config(tmp_path, shape, sloppy, expected):
+    """The config selector picks an appropriate (optionally quick) config."""
+    in_file = tmp_path / 'epi.nii.gz'
+    nb.Nifti1Image(np.zeros(shape, dtype='float32'), np.eye(4)).to_filename(in_file)
+
+    selected = _select_topup_config(str(in_file), sloppy=sloppy)
+
+    assert Path(selected).name == expected
+    assert Path(selected).exists()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Reworks `init_topup_wf` to have topup handle both head motion and SD estimation concurrently. 

A new interface `SelectPEVolumes` has been added to reduce excessive number of inputs (like in #279), based on [recommendations from the topup docs](https://fsl.fmrib.ox.ac.uk/fsl/docs/diffusion/topup/users_guide/index.html#what-data-to-acquire-in-order-to-use-topup). ATM, this is set to 3 pairs, but can be further reduced if needed.

Additionally, the padding hack needed to process images with an uneven # of slices was removed (again, [recommended by their docs](https://fsl.fmrib.ox.ac.uk/fsl/docs/diffusion/topup/FAQ/index.html#do-i-have-to-have-an-even-number-of-slices-to-use-topup)) - instead their stock configs are now present and are auto-selected based on the shape of the incoming field maps. Config file used should not have a drastic effect on the field, just the processing speed.

Given that `RobustAverage` was removed, `mc_method` is no longer needed and was removed from `init_topup_wf`. Hadn't seen a release yet so better to remove than deprecate.