### PR TITLE
fix: respect sessions when finding estimators

### DIFF
--- a/sdcflows/utils/tests/test_wrangler.py
+++ b/sdcflows/utils/tests/test_wrangler.py
@@ -433,6 +433,47 @@ phasediff = {
 }
 
 
+phasediff_b0ids = {
+    '01': [
+        {
+            'session': session,
+            'anat': [{'suffix': 'T1w', 'metadata': {'EchoTime': 1}}],
+            'fmap': [
+                {
+                    'suffix': 'phasediff',
+                    'metadata': {
+                        'EchoTime1': 1.2,
+                        'EchoTime2': 1.4,
+                        'B0FieldIdentifier': f'gre{session}',
+                    },
+                },
+                {
+                    'suffix': 'magnitude1',
+                    'metadata': {'EchoTime': 1.2, 'B0FieldIdentifier': f'gre{session}'},
+                },
+                {
+                    'suffix': 'magnitude2',
+                    'metadata': {'EchoTime': 1.4, 'B0FieldIdentifier': f'gre{session}'},
+                },
+            ],
+            'func': [
+                {
+                    'task': 'rest',
+                    'suffix': 'bold',
+                    'metadata': {
+                        'RepetitionTime': 0.8,
+                        'TotalReadoutTime': 0.5,
+                        'PhaseEncodingDirection': 'j',
+                        'B0FieldSource': f'gre{session}',
+                    },
+                }
+            ],
+        }
+        for session in ('01', '02')
+    ]
+}
+
+
 filters = {
     'fmap': {
         'datatype': 'fmap',
@@ -492,6 +533,39 @@ def test_wrangler_URIs(tmpdir, name, skeleton, session, estimations, total_estim
         intended_rel = re.sub(r'^sub-[a-zA-Z0-9]*/', '', str(Path(bold).relative_to(layout.root)))
         b0_id = get_identifier(intended_rel)
         assert b0_id == ('auto_00000',)
+
+    clear_registry()
+
+
+@pytest.mark.parametrize('bids_filters', [None, {'datatype': 'fmap'}])
+def test_sessionwise_queries(tmp_path, bids_filters):
+    """One query per session must find that session's fieldmap."""
+    bids_dir = tmp_path / 'bids'
+    generate_bids_skeleton(bids_dir, phasediff)
+    layout = gen_layout(bids_dir)
+
+    for session in ('01', '02', '03'):
+        est = find_estimators(
+            layout=layout,
+            subject='01',
+            sessions=[session],
+            bids_filters=bids_filters,
+        )
+        assert len(est) == 1
+        assert all(f'ses-{session}' in str(source.path) for source in est[0].sources)
+
+    clear_registry()
+
+
+def test_sessionwise_queries_b0ids(tmp_path):
+    """Session-specific ``B0FieldIdentifier``s are not leaked across queries."""
+    bids_dir = tmp_path / 'bids'
+    generate_bids_skeleton(bids_dir, phasediff_b0ids)
+    layout = gen_layout(bids_dir)
+
+    for session in ('01', '02'):
+        est = find_estimators(layout=layout, subject='01', sessions=[session])
+        assert [estimator.bids_id for estimator in est] == [f'gre{session}']
 
     clear_registry()
 

--- a/sdcflows/utils/wrangler.py
+++ b/sdcflows/utils/wrangler.py
@@ -332,9 +332,10 @@ def find_estimators(
 
     if bids_filters:
         filters = bids_filters.copy()  # copy to avoid altering in place
-        if 'session' in bids_filters and sessions is not None:
-            raise ValueError('Filters include session, but session is already defined.')
-        sessions = listify(filters.pop('session', None))
+        if 'session' in filters:
+            if sessions is not None:
+                raise ValueError('Filters include session, but session is already defined.')
+            sessions = listify(filters.pop('session'))
         base_entities.update(filters)
 
     subject_root = Path(layout.root) / f'sub-{subject}'
@@ -346,12 +347,13 @@ def find_estimators(
     estimators = []
 
     # Step 1. Use B0FieldIdentifier metadata
+    b0_entities = {**base_entities, 'session': sessions}
     b0_ids = ()
     with suppress(BIDSEntityError):
         # flatten lists from json (tupled in pybids for hashing), then unique
         b0_ids = reduce(
             set.union,
-            (listify(ids) for ids in layout.get_B0FieldIdentifiers(**base_entities)),
+            (listify(ids) for ids in layout.get_B0FieldIdentifiers(**b0_entities)),
             set(),
         )
 
@@ -363,12 +365,9 @@ def find_estimators(
 
         for b0_id in b0_ids:
             # Found B0FieldIdentifier metadata entries
-            b0_entities = base_entities.copy()
-            b0_entities['B0FieldIdentifier'] = b0_id
-
-            bare_ids = layout.get(**base_entities, B0FieldIdentifier=b0_id)
+            bare_ids = layout.get(**b0_entities, B0FieldIdentifier=b0_id)
             listed_ids = layout.get(
-                **base_entities,
+                **b0_entities,
                 B0FieldIdentifier=f'"{b0_id}"',  # Double quotes to match JSON, not Python repr
                 regex_search=True,
             )
@@ -382,7 +381,12 @@ def find_estimators(
                 )
             except (ValueError, TypeError) as err:
                 _log_debug_estimator_fail(
-                    logger, b0_id, bare_ids + listed_ids, layout.root, str(err)
+                    logger,
+                    b0_id,
+                    bare_ids + listed_ids,
+                    layout.root,
+                    str(err),
+                    level=logging.WARNING,
                 )
             else:
                 _log_debug_estimation(logger, e, layout.root)
@@ -645,10 +649,16 @@ def _log_debug_estimation(
 
 
 def _log_debug_estimator_fail(
-    logger: logging.Logger, b0_id: str, files: list[BIDSFile], bids_root: str, message: str
+    logger: logging.Logger,
+    b0_id: str,
+    files: list[BIDSFile],
+    bids_root: str,
+    message: str,
+    level: int = logging.DEBUG,
 ) -> None:
     """A helper function to log failures to build an estimator when running with verbosity."""
-    logger.debug(
+    logger.log(
+        level,
         'Failed to construct %s estimation from %d sources:\n- %s\nError: %s',
         b0_id,
         len(files),


### PR DESCRIPTION
``find_estimators`` discarded the caller's ``sessions`` whenever any ``bids_filters`` were given, because the session key was popped unconditionally and defaulted to None.

Addresses https://github.com/nipreps/fmriprep/issues/3664

This likely warrants a backport to the 2.15.x series(?) for fmriprep LTS